### PR TITLE
fix: fix perf bug in `mox compile`

### DIFF
--- a/moccasin/commands/compile.py
+++ b/moccasin/commands/compile.py
@@ -109,7 +109,7 @@ def compile_project(
     with multiprocessing.Pool(n_cpus) as pool:
         for contract_path in contracts_to_compile:
             res = pool.apply_async(
-                compile_,
+                compile_noret,
                 (contract_path, build_folder),
                 dict(is_zksync=is_zksync, write_data=write_data),
             )
@@ -144,7 +144,7 @@ def compile_(
     compiler_args: dict | None = None,
     is_zksync: bool = False,
     write_data: bool = False,
-) -> None:
+) -> VyperDeployer | VVMDeployer:
     logger.debug(f"Compiling contract {contract_path}")
 
     # Getting the compiler Data
@@ -201,3 +201,10 @@ def compile_(
         logger.debug(f"Compilation data saved to {build_file}")
 
     logger.debug(f"Done compiling {contract_name}")
+
+    return deployer
+
+# discard the result of the compilation so that we don't need to pickle it
+# between processes
+def compile_noret(*args, **kwargs) -> None:
+    compile_(*args, **kwargs)

--- a/moccasin/commands/compile.py
+++ b/moccasin/commands/compile.py
@@ -201,5 +201,3 @@ def compile_(
         logger.debug(f"Compilation data saved to {build_file}")
 
     logger.debug(f"Done compiling {contract_name}")
-
-    return deployer

--- a/moccasin/commands/compile.py
+++ b/moccasin/commands/compile.py
@@ -144,7 +144,7 @@ def compile_(
     compiler_args: dict | None = None,
     is_zksync: bool = False,
     write_data: bool = False,
-) -> VyperDeployer | None:
+) -> None:
     logger.debug(f"Compiling contract {contract_path}")
 
     # Getting the compiler Data


### PR DESCRIPTION
the pickling/unpickling of the VyperDeployer was a perf bottleneck. it's not used, so don't return it from the subprocess