### PR TITLE
Remove Empty Lines in Default Files (Issue #173)

### DIFF
--- a/tests/data/deployments_project/.coveragerc
+++ b/tests/data/deployments_project/.coveragerc
@@ -1,3 +1,2 @@
-
 [run]
 plugins = boa.coverage

--- a/tests/data/purge_project/.coveragerc
+++ b/tests/data/purge_project/.coveragerc
@@ -1,3 +1,2 @@
-
 [run]
 plugins = boa.coverage

--- a/tests/data/tests_project/.coveragerc
+++ b/tests/data/tests_project/.coveragerc
@@ -1,3 +1,2 @@
-
 [run]
 plugins = boa.coverage


### PR DESCRIPTION
There were three .coveragerc files with multiple empty lines which was addressed in Issue #173 . This PR contains 3 commits which remove them.