### PR TITLE
Update explorer URIs for zksync-era and sepolia-zksync-era (docs/source/_autogenerated/explorer_defaults.rst)

### DIFF
--- a/docs/source/_autogenerated/explorer_defaults.rst
+++ b/docs/source/_autogenerated/explorer_defaults.rst
@@ -146,7 +146,7 @@ multicall2 = "None"
 chain_id = 324
 
 [sepolia-zksync-era]
-explorer_uri = "https://explorer.sepolia.era.zksync.dev"
+explorer_uri = "https://explorer.sepolia.era.zksync.io"
 explorer_type = "zksyncexplorer"
 multicall2 = "None"
 chain_id = 300

--- a/docs/source/_autogenerated/explorer_defaults.rst
+++ b/docs/source/_autogenerated/explorer_defaults.rst
@@ -140,7 +140,7 @@ multicall2 = "None"
 chain_id = 321
 
 [zksync-era]
-explorer_uri = "https://zksync2-mainnet-explorer.zksync.io"
+explorer_uri = "https://explorer.zksync.io/"
 explorer_type = "zksyncexplorer"
 multicall2 = "None"
 chain_id = 324


### PR DESCRIPTION
The following updates are related to this path: (docs/source/_autogenerated/explorer_defaults.rst)

- Updated the explorer URIs for both zksync-era and sepolia-zksync-era and to reflect the correct URLs.
- The `explorer_uri` for zkSync Era was updated from `https://zksync2-mainnet-explorer.zksync.io/` to `https://explorer.zksync.io/`.
- The `explorer_uri` for Sepolia zkSync Era was updated from `https://explorer.sepolia.era.zksync.dev/` to `https://explorer.sepolia.era.zksync.io`.
- These changes were made because the previous explorer URIs were broken and returned 404 errors.

Although these updates are very minor, I wanted to dip my toes into submitting my first PR. 
