### PR TITLE
Correct typo module imports for `just test` CLI and unit fix #181

### DIFF
--- a/tests/data/complex_project/contracts/InitializedAuth.vy
+++ b/tests/data/complex_project/contracts/InitializedAuth.vy
@@ -1,6 +1,6 @@
 # pragma version ^0.4.0
 
-import auth
+import Auth as auth
 import UninitializedAuth
 
 initializes: auth

--- a/tests/data/complex_project/contracts/UninitializedAuth.vy
+++ b/tests/data/complex_project/contracts/UninitializedAuth.vy
@@ -1,5 +1,5 @@
 # pragma version ^0.4.0
-import auth
+import Auth as auth
 
 # This contract is not a valid contract. auth.__init__() must be called
 # by a contract that imports and uses this contract

--- a/tests/data/installation_project/src/MyToken.vy
+++ b/tests/data/installation_project/src/MyToken.vy
@@ -2,7 +2,7 @@
 # from snekmate.tokens import erc20
 from snekmate.auth import ownable as ow 
 from snekmate.tokens import erc20
-from PatrickAlphaC.test_repo import my_contract
+from patrickalphac.test_repo import my_contract
 
 initializes: ow
 initializes: erc20[ownable := ow]


### PR DESCRIPTION
**Related** to: #181
**OS**: Ubuntu24
**Mox version**: Moccasin CLI v0.3.6

---

Just test command failed due to wrong typo on Vyper module `import PatrickAlphaC.test_repo`

-> Fixed import in Vyper related file
```vy
from patrickalphac.test_repo import my_contract
```

Found other import failure on module `Auth` imported like auth initially:
```vy
# tests/data/complex_project/contracts/InitializedAuth.vy
import auth
```
 
 -> Fixed import by using aliases
 ```vy
 import Auth as auth
 ```