### PR TITLE
Doc: poetry installation support to add moccasin for #26

### DIFF
--- a/docs/source/installing_moccasin.rst
+++ b/docs/source/installing_moccasin.rst
@@ -148,6 +148,93 @@ To install moccasin then with ``pipx``:
 
 Then, go to :ref:`after installation <after_install>`.
 
+Installation with poetry
+========================
+
+Poetry is depedency management tool in Python. It allows to install/update libraries from your project, and also handle Python packaging.
+
+``poetry`` installs dependencies into its default virtual environment ``{cache-dir}/virtualenvs`` related to the intialized project. See how `poetry virtual environment <https://python-poetry.org/docs/basic-usage/#using-your-virtual-environment>`_ works.
+
+You can install Moccasin with ``poetry``, and if you do so, it's highly recommended you understand how `virtual environments <https://docs.python.org/3/library/venv.html>`_ work. 
+
+You can either head over to the `poetry installation instructions <https://python-poetry.org/docs/#installation>`_ or follow along below.
+
+To install ``poetry``, you'll need `pipx <https://github.com/pipxproject/pipx>`_:
+
+.. code-block:: bash
+
+    pipx install poetry
+
+.. note::
+    
+    You may need to restart your terminal after installing ``poetry``.
+
+Ensure ``poetry`` is available:
+
+.. code-block:: bash
+
+    poetry --version 
+    # Poetry (version 2.0.1)
+
+We'll need to initialize a ``poetry`` project to use its dedicated virtual enviroment to add Moccasin:
+
+.. code-block:: bash
+
+    poetry new mox-project
+    cd mox-project
+
+This will create the following directory structure for the ``mox-project`` dir:
+
+.. code-block:: console
+
+    .
+    ├── mox-project
+    │   ├── mox_project
+    │   │   └── __init__.py
+    │   ├── poetry.lock
+    │   ├── pyproject.toml
+    │   ├── README.md
+    │   └── tests
+    │       └── __init__.py
+
+You can now navigate to the ``mox-project`` folder and install Moccasin:
+
+.. code-block:: bash
+
+    cd mox-project
+    poetry add moccasin
+
+.. caution::
+    
+    You may run into an issue where the default Python version registered in the ``pyproject.toml`` is not compatible with ``moccasin``. 
+    
+    .. code-block:: console 
+
+        The current project's supported Python range (>=3.12) is not compatible with some of the required packages Python requirement:
+        - moccasin requires Python <=3.13,>=3.11, so it will not be satisfied for Python >3.13
+
+        Because no versions of moccasin match >0.3.6,<0.4.0
+        and moccasin (0.3.6) requires Python <=3.13,>=3.11, moccasin is forbidden.
+        So, because mox-project depends on moccasin (^0.3.6), version solving failed.
+
+
+    To fix this you'll have to change manually the param ``requires-python``. For example: 
+
+    .. code-block:: toml 
+
+        [project]
+        requires-python = ">=3.12,<=3.13"
+    
+    Adapt the python version at your convinience. You might need to redo ``poetry add moccasin`` until the error message from ``poetry is gone``
+
+You can then activate your ``poetry`` env:
+
+.. code-block:: bash
+    
+    eval $(poetry env activate)
+
+Then, go to :ref:`after installation <after_install>`.
+
 Installation with pip
 =====================
 

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -18,6 +18,16 @@ And this will create a new project in a new ``my_project`` directory. If you wan
 
     mox init my_project --force
 
+.. hint::
+    
+    For ``poetry``, it is recommanded to use ``--force`` inside the subfolder of your project to get the moccasin architecture. For example, here it will be ``mox_project`` and not ``mox-project``
+
+    .. code-block:: console
+        
+        .
+        ├── mox-project
+        │   ├── mox_project
+
 If you use VSCode, you can also use:
 
 .. code-block:: bash


### PR DESCRIPTION
Issue: #26 

Proposal for a documentation about poetry project with Moccasin.

- Inspired from `pipx` doc install support
- Tested locally by initializing a project and understanding how poetry handle virtual environments
- Adapted Quickstart section  too since we should init the subfolder of a poetry project (directory structure of poetry)

---

Hope it responds to the original issue. Feel free to check and clarify some points (or all of it)  :+1: 