### PR TITLE
[Issue#187] - Doc - Update readme for integration test with right env values needed

### DIFF
--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -7,5 +7,13 @@ There are tests where you need some kind of environment variable or external ser
 
 To run this folder, you'll need:
 
-1. `ETHERSCAN_API_KEY` set to an Etherscan API key
+1. `EXPLORER_API_KEY` set to an Etherscan API key
 2. `OPTIMISTIC_ETHERSCAN_API_KEY` set to an Etherscan-Optimism API key
+3. `MAINNET_RPC_URL` set to your mainnet RPC URL from your provider (like [Alchemy](https://www.alchemy.com/))
+
+> 💡 You'll have to export your env variables before running `just test-i`.
+>
+> You can create a script to export them whenever you need them.
+> For extra security, check this password management tool [pass](https://www.passwordstore.org/) to encrypt your var with `gpg`.
+>
+> Ask any contributor if you need advice.


### PR DESCRIPTION
Related issue: #187 

---

Updated README for integration test with `just test-i`.  With a little tip at the end (not developed but if needed I can).

```bash
EXPLORER_API_KEY
OPTIMISTIC_ETHERSCAN_API_KEY
MAINNET_RPC_URL
```