### PR TITLE
fix: docs - fix toml key for forking

### DIFF
--- a/docs/source/all_moccasin_toml_parameters.rst
+++ b/docs/source/all_moccasin_toml_parameters.rst
@@ -52,12 +52,12 @@ All possible options
 
     [networks.pyevm]
     # The basic EVM local network
-    # cannot set URL, chain_id, is_fork, is_zksync, prompt_live, explorer_uri, explorer_api_key
+    # cannot set URL, chain_id, fork, is_zksync, prompt_live, explorer_uri, explorer_api_key
     default_account_name = "anvil"
 
     [networks.eravm]
     # The special ZKSync Era local network
-    # cannot set URL, chain_id, is_fork, is_zksync, prompt_live, explorer_uri, explorer_api_key
+    # cannot set URL, chain_id, fork, is_zksync, prompt_live, explorer_uri, explorer_api_key
     default_account_name = "anvil"
 
     [networks.contracts]
@@ -68,7 +68,7 @@ All possible options
     [networks.sepolia]
     url = "https://ethereum-sepolia-rpc.publicnode.com"
     chain_id = 11155111
-    is_fork = false
+    fork = false
     is_zksync = false
     # This is the name of the account that will be unlocked when running on this network
     default_account_name = "anvil"

--- a/docs/source/core_concepts/networks.rst
+++ b/docs/source/core_concepts/networks.rst
@@ -8,7 +8,7 @@ Networks in ``moccasin`` are identified in your ``moccasin.toml``. The complete 
     [networks.sepolia]
     url = "https://ethereum-sepolia-rpc.publicnode.com"
     chain_id = 11155111
-    is_fork = false
+    fork = false
     is_zksync = false
     default_account_name = "anvil"
     unsafe_password_file = "~/.moccasin/password"
@@ -24,7 +24,7 @@ Let's walk through some of the options here.
 
 - ``url``: The URL of the network you are connecting to.
 - ``chain_id``: The chain ID of the network you are connecting to.
-- ``is_fork``: If you are forking a network, set this to ``true``.
+- ``fork``: If you are forking a network, set this to ``true``.
 - ``is_zksync``: If you are connecting to a zkSync network, set this to ``true``.
 - ``default_account_name``: The default account name to use when deploying contracts. This will be the name of your account you created with your :doc:`wallet <wallet>` command.
 - ``unsafe_password_file``: The location of the password file for your account. This is a file that contains the password for your account. BE SURE TO NEVER PUSH THIS PASSWORD TO GITHUB IF YOU USE THIS. 

--- a/docs/source/core_concepts/networks/forked_networks.rst
+++ b/docs/source/core_concepts/networks/forked_networks.rst
@@ -22,7 +22,7 @@ In testing, forking is an essential part of the development process. **Any scrip
     [networks.sepolia]
     url = "https://ethereum-sepolia-rpc.publicnode.com"
     chain_id = 11155111
-    is_fork = true 
+    fork = true 
 
 Running a script with this setup will run your script locally, but pretending to be on the ``sepolia`` network, with contracts and everything! 
 
@@ -35,7 +35,7 @@ You can also take any non-forked network and run a forked test just by adding th
     [networks.sepolia]
     url = "https://ethereum-sepolia-rpc.publicnode.com"
     chain_id = 11155111
-    is_fork = false 
+    fork = false 
 
  
 Forked network defaults 

--- a/moccasin/constants/vars.py
+++ b/moccasin/constants/vars.py
@@ -85,7 +85,7 @@ SPECIFIC_VALUES_FOR_ALL_LOCAL_NETWORKS = {SAVE_TO_DB: False, "db_path": None}
 RESTRICTED_VALUES_FOR_LOCAL_NETWORK = [
     "url",
     "chain_id",
-    "is_fork",
+    "fork",
     "explorer_uri",
     "exploer_api_key",
 ]


### PR DESCRIPTION
Current docs use `is_fork`, should be `fork`