### PR TITLE
Add block_identifier to config to support forking at a specific block

### DIFF
--- a/docs/source/core_concepts/networks/forked_networks.rst
+++ b/docs/source/core_concepts/networks/forked_networks.rst
@@ -37,7 +37,17 @@ You can also take any non-forked network and run a forked test just by adding th
     chain_id = 11155111
     is_fork = false 
 
- 
+
+You can fork at a specific block by specifying a ``block_identifier``, which can be either an integer or one of the preset options:  ``safe`` (default), ``latest``, ``earliest``, ``pending``, ``finalized``
+
+.. code-block:: toml
+
+    [networks.sepolia]
+    url = "https://ethereum-sepolia-rpc.publicnode.com"
+    chain_id = 11155111
+    is_fork = false
+    block_identifier = 7582167
+
 Forked network defaults 
 ========================
 

--- a/moccasin/config.py
+++ b/moccasin/config.py
@@ -78,6 +78,7 @@ class Network:
     url: str | None = None
     chain_id: int | None = None
     is_fork: bool = False
+    block_identifier: int | str = "safe"
     is_zksync: bool = False
     default_account_name: str | None = None
     unsafe_password_file: Path | None = None
@@ -103,9 +104,9 @@ class Network:
         # 1. Check for forking, and set (You cannot fork from a NetworkEnv, only a "new" Env!)
         if self.is_fork:
             if self.is_zksync:
-                set_zksync_fork(url=self.url)
+                set_zksync_fork(url=self.url, block_identifier=self.block_identifier)
             else:
-                boa.fork(self.url)
+                boa.fork(self.url, block_identifier=self.block_identifier)
 
         # 2. Non-forked local networks
         elif self.name == PYEVM:
@@ -850,6 +851,7 @@ class _Networks:
                 network = Network(
                     name=network_name,
                     is_fork=network_data.get("fork", False),
+                    block_identifier=network_data.get("block_identifier", "safe"),
                     url=network_data.get("url", None),
                     is_zksync=network_data.get("is_zksync", False),
                     chain_id=network_data.get("chain_id", None),

--- a/moccasin/constants/vars.py
+++ b/moccasin/constants/vars.py
@@ -86,6 +86,7 @@ RESTRICTED_VALUES_FOR_LOCAL_NETWORK = [
     "url",
     "chain_id",
     "is_fork",
+    "block_identifier",
     "explorer_uri",
     "exploer_api_key",
 ]

--- a/tests/data/complex_project/moccasin.toml
+++ b/tests/data/complex_project/moccasin.toml
@@ -78,6 +78,7 @@ save_to_db = false
 url = "${MAINNET_RPC_URL}"
 fork = true
 explorer_uri = "https://api.etherscan.io/api"
+block_identifier = 21000000
 
 [networks.mainnet_fork.contracts]
 usdc = { address = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48", abi_from_explorer = true }


### PR DESCRIPTION
Currently the block at which a chain is forked is not configurable and defaults to `safe`. Users may however want to run tests at specific blocks in the past. Furthermore RPCs for chains like Polygon often fail when trying to fetch a safe block.

I added the option to the `complex_project`'s config file, but did not write a specific test for it. If you would like a specific test, please let me know where.