### PR TITLE
[Issue-#186] - Fix - Windows issues on mox cli command and utils argparser

### DIFF
--- a/moccasin/__main__.py
+++ b/moccasin/__main__.py
@@ -61,9 +61,9 @@ def main(argv: list) -> int:
     return 0
 
 
-def generate_main_parser_and_sub_parsers() -> (
-    Tuple[argparse.ArgumentParser, argparse.Action]
-):
+def generate_main_parser_and_sub_parsers() -> Tuple[
+    argparse.ArgumentParser, argparse.Action
+]:
     parent_parser = create_parent_parser()
     main_parser = argparse.ArgumentParser(
         prog="Moccasin CLI",
@@ -650,17 +650,21 @@ This command will attempt to use the environment variable ETHERSCAN_API_KEY as t
     # ------------------------------------------------------------------
     #                         UTILS COMMAND
     # ------------------------------------------------------------------
-    utils_paraser = sub_parsers.add_parser(
+    utils_parser = sub_parsers.add_parser(
         "utils",
         aliases=["u", "util"],
         help="Helpful utilities - right now it's just the one.",
         description="Helpful utilities.\n",
         parents=[parent_parser],
     )
-    utils_subparaser = utils_paraser.add_subparsers(dest="utils_command")
+    utils_parser.add_argument(
+        "utils_command", help="Name of the utility command to get."
+    )
+
+    utils_subparser = utils_parser.add_subparsers(dest="utils_command")
 
     # Zero
-    utils_subparaser.add_parser(
+    utils_subparser.add_parser(
         "zero",
         aliases=["zero-address", "zero_address", "address-zero", "address_zero"],
         help="Get the zero address.",

--- a/moccasin/commands/compile.py
+++ b/moccasin/commands/compile.py
@@ -20,6 +20,7 @@ from moccasin.constants.vars import (
     BUILD_FOLDER,
     CONTRACTS_FOLDER,
     ERAVM,
+    IS_WINDOWS,
     MOCCASIN_GITHUB,
 )
 from moccasin.logging import logger
@@ -107,7 +108,12 @@ def compile_project(
         f"Compiling {len(contracts_to_compile)} contracts to {build_folder_relpath}/..."
     )
 
-    multiprocessing.set_start_method("fork", force=False)
+    # @dev check if OS is Windows since fork
+    # is not supported on Windows, change it to spawn method
+    start_method = "fork"
+    if IS_WINDOWS:
+        start_method = "spawn"
+    multiprocessing.set_start_method(start_method, force=False)
 
     n_cpus = max(1, _get_cpu_count() - 2)
     jobs = []

--- a/moccasin/commands/init.py
+++ b/moccasin/commands/init.py
@@ -100,5 +100,5 @@ def _create_files(
 
 def _write_file(path: Path, contents: str, overwrite: bool = False) -> None:
     if not path.exists() or overwrite:
-        with path.open("w") as fp:
+        with path.open("w", encoding="utf-8") as fp:
             fp.write(contents)

--- a/moccasin/constants/vars.py
+++ b/moccasin/constants/vars.py
@@ -1,5 +1,6 @@
 import os
 from pathlib import Path
+import platform
 
 # File Names
 README_PATH = "README.md"
@@ -28,6 +29,9 @@ REQUEST_HEADERS = {"User-Agent": "Moccasin"}
 PACKAGE_VERSION_FILE = "versions.toml"
 PYPI = "pypi"
 GITHUB = "github"
+
+# OS specific
+IS_WINDOWS = platform.system() == "Windows"
 
 # Complex Vars
 DEFAULT_PROJECT_FOLDERS = [

--- a/moccasin/constants/vars.py
+++ b/moccasin/constants/vars.py
@@ -1,6 +1,6 @@
 import os
-from pathlib import Path
 import platform
+from pathlib import Path
 
 # File Names
 README_PATH = "README.md"


### PR DESCRIPTION
Related issue: #186 

---

- `init.py`: Windows error `(UnicodeEncodeError: 'charmap' codec can't encode character '\U0001f40d')` when the param `encoding="utf-8" for `open` is not set
- `compile.py`: Windows does not support `fork` method for `multiprocessing.set_start_method()`, hence changed to "spawn"
- `vars.py`: added general constant `IS_WINDOWS` for future use and avoid any duplicates
- fixed utils CLI command running an error when no arguments passed + fixed some var typo