### PR TITLE
Auto-install dependencies for build and deploy and rework for #174

### DIFF
--- a/moccasin/__main__.py
+++ b/moccasin/__main__.py
@@ -140,6 +140,12 @@ Use this command to prepare your contracts for deployment or testing.""",
         help="Optional argument to compile a specific contract.",
     )
 
+    compile_parser.add_argument(
+        "--no-install",
+        help="Do not install the requirements before compiling.",
+        action="store_true",
+    )
+
     zksync_ground = compile_parser.add_mutually_exclusive_group()
     zksync_ground.add_argument(
         "--network", help=f"Alias of the network (from the {CONFIG_NAME})."
@@ -322,6 +328,13 @@ Use this command to prepare your contracts for deployment or testing.""",
         type=str,
         default="./script/deploy.py",
     )
+
+    run_parser.add_argument(
+        "--no-install",
+        help="Do not install the requirements before running the script.",
+        action="store_true",
+    )
+
     add_network_args_to_parser(run_parser)
     add_account_args_to_parser(run_parser)
 

--- a/moccasin/__main__.py
+++ b/moccasin/__main__.py
@@ -175,6 +175,11 @@ Use this command to prepare your contracts for deployment or testing.""",
         nargs="?",
     )
     test_parser.add_argument(
+        "--no-install",
+        help="Do not install the requirements before running the tests.",
+        action="store_true",
+    )
+    test_parser.add_argument(
         "--update-packages",
         help="Update the packages before running the tests.",
         action="store_true",
@@ -369,6 +374,12 @@ Use this command to prepare your contracts for deployment or testing.""",
         "contract_name",
         help=f"Name of your named contract in your {CONFIG_NAME} to deploy.",
         type=str,
+    )
+
+    deploy_parser.add_argument(
+        "--no-install",
+        help="Do not install the requirements before deploying.",
+        action="store_true",
     )
 
     deploy_parser.add_argument(

--- a/moccasin/__main__.py
+++ b/moccasin/__main__.py
@@ -149,7 +149,7 @@ Use this command to prepare your contracts for deployment or testing.""",
     compile_parser.add_argument(
         "--update-packages",
         help="Update the packages before running the script.",
-        action="store_false",
+        action="store_true",
     )
 
     zksync_ground = compile_parser.add_mutually_exclusive_group()
@@ -174,6 +174,12 @@ Use this command to prepare your contracts for deployment or testing.""",
         type=str,
         nargs="?",
     )
+    test_parser.add_argument(
+        "--update-packages",
+        help="Update the packages before running the tests.",
+        action="store_true",
+    )
+
     add_network_args_to_parser(test_parser)
     add_account_args_to_parser(test_parser)
 
@@ -344,7 +350,7 @@ Use this command to prepare your contracts for deployment or testing.""",
     run_parser.add_argument(
         "--update-packages",
         help="Update the packages before running the script.",
-        action="store_false",
+        action="store_true",
     )
 
     add_network_args_to_parser(run_parser)
@@ -363,6 +369,12 @@ Use this command to prepare your contracts for deployment or testing.""",
         "contract_name",
         help=f"Name of your named contract in your {CONFIG_NAME} to deploy.",
         type=str,
+    )
+
+    deploy_parser.add_argument(
+        "--update-packages",
+        help="Update the packages before deploying the contract.",
+        action="store_true",
     )
     add_network_args_to_parser(deploy_parser)
     add_account_args_to_parser(deploy_parser)

--- a/moccasin/__main__.py
+++ b/moccasin/__main__.py
@@ -146,6 +146,12 @@ Use this command to prepare your contracts for deployment or testing.""",
         action="store_true",
     )
 
+    compile_parser.add_argument(
+        "--update-packages",
+        help="Update the packages before running the script.",
+        action="store_false",
+    )
+
     zksync_ground = compile_parser.add_mutually_exclusive_group()
     zksync_ground.add_argument(
         "--network", help=f"Alias of the network (from the {CONFIG_NAME})."
@@ -333,6 +339,12 @@ Use this command to prepare your contracts for deployment or testing.""",
         "--no-install",
         help="Do not install the requirements before running the script.",
         action="store_true",
+    )
+
+    run_parser.add_argument(
+        "--update-packages",
+        help="Update the packages before running the script.",
+        action="store_false",
     )
 
     add_network_args_to_parser(run_parser)

--- a/moccasin/_dependency_utils.py
+++ b/moccasin/_dependency_utils.py
@@ -1,6 +1,7 @@
 import re
 from dataclasses import dataclass
 from enum import Enum
+from typing import Tuple
 
 from packaging.requirements import InvalidRequirement, Requirement
 
@@ -23,6 +24,117 @@ def classify_dependency(dependency: str) -> DependencyType:
         return DependencyType.GITHUB
 
     return DependencyType.PIP
+
+
+def get_dependencies_to_install(requirements: list[str]) -> Tuple[list[str], list[str]]:
+    """Return a tuple with the pip and github dependencies.
+
+    :param requirements: List of requirements to parse
+    :type requirements: list[str]
+    :return: Tuple with the pip and github dependencies
+    :rtype: Tuple[list[str], list[str]]
+    """
+    # Init dependencies lists
+    pip_dependencies = []
+    github_dependencies = []
+
+    # Check if we have any requirements to parse
+    if len(requirements) == 0:
+        requirements = get_or_initialize_config().get_dependencies()
+    if len(requirements) == 0:
+        # If we have no requirements, return dict with empty lists
+        return {DependencyType.PIP: [], DependencyType.GITHUB: []}
+
+    # Populate requirements lists
+    for requirement in requirements:
+        if classify_dependency(requirement) == DependencyType.GITHUB:
+            github_dependencies.append(requirement)
+        else:
+            pip_dependencies.append(requirement)
+
+    return (pip_dependencies, github_dependencies)
+
+
+def _get_typed_packages_requirements(
+    dependency_type: DependencyType,
+) -> list[Requirement | "GitHubDependency"]:
+    """Return a list of typed requirements.
+
+    :param dependency_type: Dependency type (pip or github)
+    :type dependency_type: DependencyType
+    :return: List of typed requirements
+    :rtype: list[Requirement | "GitHubDependency"]
+    """
+    config = get_or_initialize_config()
+    dependencies = config.get_dependencies()
+
+    typed_dependencies = [
+        preprocess_requirement(dep)
+        for dep in dependencies
+        if classify_dependency(dep) == dependency_type
+    ]
+
+    if dependency_type == DependencyType.PIP:
+        return [Requirement(dep) for dep in typed_dependencies]
+    else:
+        return [GitHubDependency.from_string(dep) for dep in typed_dependencies]
+
+
+# ------------------------------------------------------------------
+#                               WIP
+# ------------------------------------------------------------------
+def _is_package_to_update(
+    package_id: str,
+    package_requirements: list[Requirement | "GitHubDependency"],
+    dependency_type: DependencyType,
+) -> bool:
+    to_delete: set[str] = set()
+    updated_packages: set[str] = set()
+    if dependency_type == DependencyType.PIP:
+        try:
+            processed_package = preprocess_requirement(package_id)
+            package_req = Requirement(processed_package)
+        except InvalidRequirement:
+            logger.warning(f"Invalid requirement format for package: {package_id}")
+
+        for dep_req in package_requirements:
+            if dep_req.name == package_req.name:
+                to_delete.add(dep_req.name)
+                updated_packages.add(package_req.name)
+
+        # if package_req.name not in updated_packages:
+        #     logger.info(f"Installed new package: {package}")
+        # else:
+        #     logger.info(f"Updated package: {package}")
+    else:  # GIT dependencies
+        package_dep = GitHubDependency.from_string(package_id)
+        for dep_gh in package_requirements:
+            if dep_gh.org == package_dep.org and dep_gh.repo == package_dep.repo:
+                to_delete.add(dep_gh.full_string)
+                updated_packages.add(package_dep.format_no_version())
+
+    return (to_delete, updated_packages)
+
+    # if f"{package_dep.org}/{package_dep.repo}" not in updated_packages:
+    #         logger.info(f"Installed {package}")
+    #     else:
+    #         logger.info(f"Updated {package}")
+
+    # # Remove old versions of updated packages
+    # dependencies = [dep for dep in dependencies if dep not in to_delete]
+
+    # # Add new packages while preserving order
+    # new_deps = []
+    # for dep in dependencies + new_package_ids:
+    #     if dep not in new_deps:
+    #         new_deps.append(dep)
+
+    # return new_deps
+
+
+# ------------------------------------------------------------------
+#                               WIP
+# ------------------------------------------------------------------
 
 
 def _write_new_dependencies(
@@ -96,6 +208,7 @@ def preprocess_requirement(package: str) -> str:
 
 @dataclass
 class GitHubDependency:
+    full_string: str
     org: str
     repo: str
     version: str | None = None
@@ -107,11 +220,12 @@ class GitHubDependency:
         else:
             path, version = dep_string, None
 
+        full_string = dep_string
         org, repo = str(path).split("/")
         org = org.strip().lower()
         repo = repo.strip().lower()
         version = version.strip() if version else None
-        return cls(org, repo, version)
+        return cls(full_string, org, repo, version)
 
     def format_no_version(self) -> str:
         return f"{self.org}/{self.repo}"

--- a/moccasin/_dependency_utils.py
+++ b/moccasin/_dependency_utils.py
@@ -1,10 +1,17 @@
+import os
 import re
+import requests  # type: ignore
+import tomllib
+import tomli_w
+
+from base64 import b64encode
 from dataclasses import dataclass
 from enum import Enum
+from pathlib import Path
 from typing import Tuple
-
 from packaging.requirements import InvalidRequirement, Requirement
 
+from moccasin.constants.vars import PACKAGE_VERSION_FILE, REQUEST_HEADERS
 from moccasin.config import get_or_initialize_config
 from moccasin.logging import logger
 
@@ -14,6 +21,9 @@ class DependencyType(Enum):
     PIP = "pip"
 
 
+# ------------------------------------------------------------------
+#                       HANDLE DEPENDENCIES
+# ------------------------------------------------------------------
 def classify_dependency(dependency: str) -> DependencyType:
     dependency = dependency.strip().strip("'\"")
 
@@ -26,7 +36,7 @@ def classify_dependency(dependency: str) -> DependencyType:
     return DependencyType.PIP
 
 
-def get_dependencies_to_install(requirements: list[str]) -> Tuple[list[str], list[str]]:
+def get_dependencies(requirements: list[str]) -> Tuple[list[str], list[str]]:
     """Return a tuple with the pip and github dependencies.
 
     :param requirements: List of requirements to parse
@@ -55,90 +65,215 @@ def get_dependencies_to_install(requirements: list[str]) -> Tuple[list[str], lis
     return (pip_dependencies, github_dependencies)
 
 
-def _get_typed_packages_requirements(
-    dependency_type: DependencyType,
-) -> list[Requirement | "GitHubDependency"]:
-    """Return a list of typed requirements.
+# ------------------------------------------------------------------
+#                         PIP DEPENDENCIES
+# ------------------------------------------------------------------
+def get_new_or_updated_pip_dependencies(
+    pip_packages: list[str], base_install_path: Path
+) -> list[Requirement]:
+    """Return a list of new or updated pip packages.
 
-    :param dependency_type: Dependency type (pip or github)
-    :type dependency_type: DependencyType
-    :return: List of typed requirements
-    :rtype: list[Requirement | "GitHubDependency"]
+    :param pip_packages: List of pip packages with optional version specifiers
+    :type pip_packages: list[str]
+    :param base_install_path: Base install path
+    :type base_install_path: Path
+    :return: List of new or updated pip packages
+    :rtype: list[Requirement]
     """
-    config = get_or_initialize_config()
-    dependencies = config.get_dependencies()
+    new_or_updated = []
 
-    typed_dependencies = [
-        preprocess_requirement(dep)
-        for dep in dependencies
-        if classify_dependency(dep) == dependency_type
-    ]
+    versions_install_path = base_install_path.joinpath(PACKAGE_VERSION_FILE)
+    if not versions_install_path.exists():
+        # If versions file doesn't exist, all packages need to be installed
+        return [Requirement(package) for package in pip_packages]
 
-    if dependency_type == DependencyType.PIP:
-        return [Requirement(dep) for dep in typed_dependencies]
-    else:
-        return [GitHubDependency.from_string(dep) for dep in typed_dependencies]
+    with open(versions_install_path, "rb") as f:
+        versions = tomllib.load(f)
+        versions = {k.lower(): v for k, v in versions.items()}
 
-
-# ------------------------------------------------------------------
-#                               WIP
-# ------------------------------------------------------------------
-def _is_package_to_update(
-    package_id: str,
-    package_requirements: list[Requirement | "GitHubDependency"],
-    dependency_type: DependencyType,
-) -> bool:
-    to_delete: set[str] = set()
-    updated_packages: set[str] = set()
-    if dependency_type == DependencyType.PIP:
+    for package in pip_packages:
         try:
-            processed_package = preprocess_requirement(package_id)
+            processed_package = preprocess_requirement(package)
             package_req = Requirement(processed_package)
         except InvalidRequirement:
-            logger.warning(f"Invalid requirement format for package: {package_id}")
+            logger.warning(f"Invalid requirement format for package: {package}")
+            continue
 
-        for dep_req in package_requirements:
-            if dep_req.name == package_req.name:
-                to_delete.add(dep_req.name)
-                updated_packages.add(package_req.name)
+        package_name = package_req.name
 
-        # if package_req.name not in updated_packages:
-        #     logger.info(f"Installed new package: {package}")
-        # else:
-        #     logger.info(f"Updated package: {package}")
-    else:  # GIT dependencies
-        package_dep = GitHubDependency.from_string(package_id)
-        for dep_gh in package_requirements:
-            if dep_gh.org == package_dep.org and dep_gh.repo == package_dep.repo:
-                to_delete.add(dep_gh.full_string)
-                updated_packages.add(package_dep.format_no_version())
+        installed_version = versions.get(package_name.lower())
+        if installed_version is None:
+            new_or_updated.append(package_req)
+            logger.info(f"Package {package_name} not installed")
+            continue
 
-    return (to_delete, updated_packages)
+        # Extract version number
+        version_pattern = re.compile(r"^([\w.-]+)(?:(==|>=|<=|!=|~=|>|<)(.+))?$")
+        match = version_pattern.match(installed_version)
+        version_number = match.group(3)
 
-    # if f"{package_dep.org}/{package_dep.repo}" not in updated_packages:
-    #         logger.info(f"Installed {package}")
-    #     else:
-    #         logger.info(f"Updated {package}")
+        # If version number doesn't match requirement, package needs to be updated
+        if version_number is not None and version_number != package_req.specifier:
+            new_or_updated.append(package_req)
+            logger.info(f"Package {package_name} needs to be updated")
 
-    # # Remove old versions of updated packages
-    # dependencies = [dep for dep in dependencies if dep not in to_delete]
-
-    # # Add new packages while preserving order
-    # new_deps = []
-    # for dep in dependencies + new_package_ids:
-    #     if dep not in new_deps:
-    #         new_deps.append(dep)
-
-    # return new_deps
+    return new_or_updated
 
 
 # ------------------------------------------------------------------
-#                               WIP
+#                         GH DEPENDENCIES
 # ------------------------------------------------------------------
+@dataclass
+class GitHubDependency:
+    org: str
+    repo: str
+    version: str | None = None
+    headers: dict | None = None
+
+    @classmethod
+    def from_string(cls, dep_string: str) -> "GitHubDependency":
+        try:
+            if "@" in dep_string:
+                path, version = dep_string.split("@")
+            else:
+                path, version = dep_string, None
+
+            org, repo = str(path).split("/")
+        except ValueError:
+            raise ValueError(
+                "Invalid package ID. Must be given as ORG/REPO[@VERSION]"
+                "\ne.g. 'pcaversaccio/snekmate@v2.5.0'"
+            ) from None
+        org = org.strip().lower()
+        repo = repo.strip().lower()
+        version = version.strip() if version else None
+        return cls(org, repo, version)
+
+    def format_no_version(self) -> str:
+        return f"{self.org}/{self.repo}"
+
+    def __str__(self) -> str:
+        if self.version:
+            return f"{self.org}/{self.repo}@{self.version}"
+        return self.format_no_version()
 
 
-def _write_new_dependencies(
-    new_package_ids: list[str], dependency_type: DependencyType
+def get_new_or_updated_github_dependencies(
+    github_ids: list[str], base_install_path: Path
+):
+    """Return a list of new or updated GitHub dependencies.
+
+    :param github_ids: List of GitHub dependency IDs
+    :type github_ids: list[str]
+    :param base_install_path: Base install path
+    :type base_install_path: Path
+    :return: List of new or updated GitHub dependencies
+    :rtype: list[str]
+    """
+    new_or_updated = []
+    for package_id in github_ids:
+        github_dependency = GitHubDependency.from_string(package_id)
+
+        headers = REQUEST_HEADERS.copy()
+        headers.update(_maybe_retrieve_github_auth())
+
+        if github_dependency.headers is None:
+            github_dependency.headers = headers
+
+        if github_dependency.version is None:
+            github_dependency.version = _get_latest_github_version(
+                github_dependency.org, github_dependency.repo, github_dependency.headers
+            )
+            logger.info(
+                f"Using latest version for {github_dependency.org}/{github_dependency.repo}: {github_dependency.version}"
+            )
+
+        versions_install_path = base_install_path.joinpath(PACKAGE_VERSION_FILE)
+        if versions_install_path.exists():
+            with open(versions_install_path, "rb") as f:
+                versions = tomllib.load(f)
+                versions = {k.lower(): v for k, v in versions.items()}
+                installed_version = versions.get(
+                    f"{github_dependency.org}/{github_dependency.repo}", None
+                )
+            if installed_version == github_dependency.version:
+                logger.info(
+                    f"{github_dependency.org}/{github_dependency.repo} already installed at version {github_dependency.version}"
+                )
+                continue
+            else:
+                logger.info(
+                    f"{github_dependency.org}/{github_dependency.repo} needs to be updated from version {installed_version} to {github_dependency.version}"
+                )
+                new_or_updated.append(github_dependency)
+        else:
+            # If versions file doesn't exist, all packages need to be installed
+            new_or_updated.append(github_dependency)
+
+    return new_or_updated
+
+
+def _maybe_retrieve_github_auth() -> dict[str, str]:
+    """Returns appropriate github authorization headers.
+
+    Otherwise returns an empty dict if no auth token is present.
+    """
+    token = os.getenv("GITHUB_TOKEN")
+    if token is not None:
+        auth = b64encode(token.encode()).decode()
+        return {"Authorization": f"Basic {auth}"}
+    return {}
+
+
+def _get_latest_github_version(org: str, repo: str, headers: dict) -> str:
+    response = requests.get(
+        f"https://api.github.com/repos/{org}/{repo}/releases/latest", headers=headers
+    )
+    if response.status_code == 200:
+        return response.json()["tag_name"].lstrip("v")
+
+    response = requests.get(
+        f"https://api.github.com/repos/{org}/{repo}/tags?per_page=1", headers=headers
+    )
+    if response.status_code == 200:
+        data = response.json()
+        if data:
+            return data[0]["name"].lstrip("v")
+
+    raise ValueError(f"Unable to determine latest version for {org}/{repo}")
+
+
+# ------------------------------------------------------------------
+#                        WRITE DEPENDENCIES
+# ------------------------------------------------------------------
+def add_dependency_to_versions_file(
+    versions_install_path: Path, dependency: GitHubDependency | Requirement
+):
+    # Update versions file
+    if versions_install_path.exists():
+        with open(versions_install_path, "rb") as f:
+            versions_data = tomllib.load(f)
+        if isinstance(dependency, GitHubDependency):
+            versions_data[f"{dependency.org}/{dependency.repo}"] = dependency.version
+        else:
+            versions_data[f"{dependency.name}"] = str(dependency)
+
+        with open(versions_install_path, "wb") as f:
+            tomli_w.dump(versions_data, f)
+    else:
+        with open(versions_install_path, "w", encoding="utf-8") as f:
+            if isinstance(dependency, GitHubDependency):
+                toml_string = tomli_w.dumps(
+                    {f"{dependency.org}/{dependency.repo}": dependency.version}
+                )
+            else:
+                toml_string = tomli_w.dumps({dependency.name: str(dependency)})
+            f.write(toml_string)
+
+
+def write_new_config_dependencies(
+    new_package_ids: list[GitHubDependency | Requirement],
+    dependency_type: DependencyType,
 ):
     config = get_or_initialize_config()
     dependencies = config.get_dependencies()
@@ -153,13 +288,7 @@ def _write_new_dependencies(
     updated_packages = set()
 
     if dependency_type == DependencyType.PIP:
-        for package in new_package_ids:
-            try:
-                processed_package = preprocess_requirement(package)
-                package_req = Requirement(processed_package)
-            except InvalidRequirement:
-                logger.warning(f"Invalid requirement format for package: {package}")
-                continue
+        for package_req in new_package_ids:
             for dep in typed_dependencies:
                 dep_req = Requirement(dep)
                 if dep_req.name == package_req.name:
@@ -167,12 +296,11 @@ def _write_new_dependencies(
                     updated_packages.add(package_req.name)
 
             if package_req.name not in updated_packages:
-                logger.info(f"Installed new package: {package}")
+                logger.info(f"Installed new package: {str(package_req)}")
             else:
-                logger.info(f"Updated package: {package}")
+                logger.info(f"Updated package: {str(package_req)}")
     else:  # GIT dependencies
-        for package in new_package_ids:
-            package_dep = GitHubDependency.from_string(package)
+        for package_dep in new_package_ids:
             for dep in typed_dependencies:
                 dep_gh = GitHubDependency.from_string(dep)
                 if dep_gh.org == package_dep.org and dep_gh.repo == package_dep.repo:
@@ -180,16 +308,17 @@ def _write_new_dependencies(
                     updated_packages.add(package_dep.format_no_version())
 
             if f"{package_dep.org}/{package_dep.repo}" not in updated_packages:
-                logger.info(f"Installed {package}")
+                logger.info(f"Installed {str(package_dep)}")
             else:
-                logger.info(f"Updated {package}")
+                logger.info(f"Updated {str(package_dep)}")
 
     # Remove old versions of updated packages
     dependencies = [dep for dep in dependencies if dep not in to_delete]
 
     # Add new packages while preserving order
     new_deps = []
-    for dep in dependencies + new_package_ids:
+    # @dev Could be better here maybe
+    for dep in dependencies + [str(package) for package in new_package_ids]:
         if dep not in new_deps:
             new_deps.append(dep)
 
@@ -204,33 +333,3 @@ def preprocess_requirement(package: str) -> str:
         package_name = package.split("/")[-1].replace(".git", "")
         return package_name
     return package
-
-
-@dataclass
-class GitHubDependency:
-    full_string: str
-    org: str
-    repo: str
-    version: str | None = None
-
-    @classmethod
-    def from_string(cls, dep_string: str) -> "GitHubDependency":
-        if "@" in dep_string:
-            path, version = dep_string.split("@")
-        else:
-            path, version = dep_string, None
-
-        full_string = dep_string
-        org, repo = str(path).split("/")
-        org = org.strip().lower()
-        repo = repo.strip().lower()
-        version = version.strip() if version else None
-        return cls(full_string, org, repo, version)
-
-    def format_no_version(self) -> str:
-        return f"{self.org}/{self.repo}"
-
-    def __str__(self) -> str:
-        if self.version:
-            return f"{self.org}/{self.repo}@{self.version}"
-        return self.format_no_version()

--- a/moccasin/_dependency_utils.py
+++ b/moccasin/_dependency_utils.py
@@ -400,7 +400,7 @@ def _get_latest_github_version(org: str, repo: str, headers: dict) -> str:
 # ------------------------------------------------------------------
 #                        WRITE DEPENDENCIES
 # ------------------------------------------------------------------
-def add_dependency_to_versions_file(
+def write_dependency_to_versions_file(
     versions_install_path: Path, dependency: GitHubDependency | PipDependency
 ):
     """Update the versions file with a new or updated dependency.
@@ -410,7 +410,6 @@ def add_dependency_to_versions_file(
     :param dependency: Dependency to add or update
     :type dependency: GitHubDependency | PipDependency
     """
-    # Update versions file
     if versions_install_path.exists():
         with open(versions_install_path, "rb") as f:
             versions_data = tomllib.load(f)

--- a/moccasin/_dependency_utils.py
+++ b/moccasin/_dependency_utils.py
@@ -53,7 +53,7 @@ def get_dependencies(requirements: list[str]) -> Tuple[list[str], list[str]]:
         requirements = get_or_initialize_config().get_dependencies()
     if len(requirements) == 0:
         # If we have no requirements, return dict with empty lists
-        return {DependencyType.PIP: [], DependencyType.GITHUB: []}
+        return (pip_dependencies, github_dependencies)
 
     # Populate requirements lists
     for requirement in requirements:

--- a/moccasin/_dependency_utils.py
+++ b/moccasin/_dependency_utils.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from typing import Tuple
 from packaging.requirements import InvalidRequirement, Requirement, SpecifierSet
 
-from moccasin.constants.vars import PACKAGE_VERSION_FILE, REQUEST_HEADERS
+from moccasin.constants.vars import GITHUB, PACKAGE_VERSION_FILE, PYPI, REQUEST_HEADERS
 from moccasin.config import get_or_initialize_config
 from moccasin.logging import logger
 
@@ -36,106 +36,138 @@ def classify_dependency(dependency: str) -> DependencyType:
     return DependencyType.PIP
 
 
-def get_dependencies(requirements: list[str]) -> Tuple[list[str], list[str]]:
+def get_new_or_updated_dependencies(
+    requirements: list[str], config_dependencies: list[str], base_install_path: Path
+) -> Tuple[list["PipDependency"], list["GitHubDependency"]]:
     """Return a tuple with the pip and github dependencies.
 
     :param requirements: List of requirements to parse
     :type requirements: list[str]
     :return: Tuple with the pip and github dependencies
-    :rtype: Tuple[list[str], list[str]]
+    :rtype: Tuple[list["PipDependency"], list["GitHubDependency"]]
     """
-    # Init dependencies lists
-    pip_dependencies = []
-    github_dependencies = []
 
-    # Check if we have any requirements to parse
-    if len(requirements) == 0:
-        requirements = get_or_initialize_config().get_dependencies()
-    if len(requirements) == 0:
+    # Get pip and github paths
+    pip_install_path = base_install_path.joinpath(PYPI)
+    github_install_path = base_install_path.joinpath(GITHUB)
+
+    # Get versions toml files
+    pip_versions_toml = _get_install_path_versions_toml(pip_install_path)
+    github_versions_toml = _get_install_path_versions_toml(github_install_path)
+
+    # Init dependencies lists
+    pip_new_or_updated: list["PipDependency"] = []
+    github_new_or_updated: list["GitHubDependency"] = []
+    project_requirements = config_dependencies + requirements
+
+    # # Check if we have any requirements to parse
+    if len(project_requirements) == 0:
         # If we have no requirements, return dict with empty lists
-        return (pip_dependencies, github_dependencies)
+        return (pip_new_or_updated, github_new_or_updated)
 
     # Populate requirements lists
-    for requirement in requirements:
-        if classify_dependency(requirement) == DependencyType.GITHUB:
-            github_dependencies.append(requirement)
+    for package in project_requirements:
+        if classify_dependency(package) == DependencyType.PIP:
+            pip_req = _get_new_or_updated_pip_dependency(package, pip_versions_toml)
+            if pip_req is not None:
+                pip_new_or_updated.append(pip_req)
         else:
-            pip_dependencies.append(requirement)
+            github_req = _get_new_or_updated_github_dependency(
+                package, github_versions_toml
+            )
+            if github_req is not None:
+                github_new_or_updated.append(github_req)
 
-    return (pip_dependencies, github_dependencies)
+    return (pip_new_or_updated, github_new_or_updated)
+
+
+def _get_install_path_versions_toml(lib_install_path: Path) -> dict[str, str]:
+    # Get install path and check if versions file exists
+    versions_toml: dict[str, str] = {}
+    versions_install_path = lib_install_path.joinpath(PACKAGE_VERSION_FILE)
+    if not versions_install_path.exists():
+        return versions_toml
+
+    # If versions file exists, check if packages need to be updated
+    with open(versions_install_path, "rb") as f:
+        versions = tomllib.load(f)
+        versions_toml = {k.lower(): v for k, v in versions.items()}
+
+    return versions_toml
 
 
 # ------------------------------------------------------------------
 #                         PIP DEPENDENCIES
 # ------------------------------------------------------------------
-def get_new_or_updated_pip_dependencies(
-    pip_packages: list[str], base_install_path: Path
-) -> list[Requirement]:
-    """Return a list of new or updated pip packages.
+@dataclass
+class PipDependency:
+    requirement: Requirement
+    no_version: bool = False
 
-    :param pip_packages: List of pip packages with optional version specifiers
-    :type pip_packages: list[str]
-    :param base_install_path: Base install path
-    :type base_install_path: Path
+    def __str__(self) -> str:
+        return str(self.requirement)
+
+
+def _get_new_or_updated_pip_dependency(
+    package: str, pip_versions_toml: dict[str, str]
+) -> PipDependency | None:
+    """Return a new or updated pip packages.
+
+    :param package: Pip package with optional version specifier
+    :type package: str
+    :param pip_install_path: Pip install path
+    :type pip_install_path: Path
     :return: List of new or updated pip packages
     :rtype: list[Requirement]
     """
-    new_or_updated = []
+    no_version = False
+    # Try to parse the package as a pip requirement
+    try:
+        # Preprocess package name
+        processed_package = preprocess_requirement(package)
+        package_req = Requirement(processed_package)
+        if package_req.specifier is None:
+            no_version = True
+            package_req.specifier = SpecifierSet(
+                f"=={_get_latest_pip_version(package_req.name)}"
+            )
+    except InvalidRequirement:
+        logger.warning(f"Invalid requirement format for package: {package}")
+        return None
 
-    versions_install_path = base_install_path.joinpath(PACKAGE_VERSION_FILE)
-    if not versions_install_path.exists():
-        # If versions file doesn't exist, all packages need to be installed
-        for package in pip_packages:
-            try:
-                # Preprocess package name
-                processed_package = preprocess_requirement(package)
-                package_req = Requirement(processed_package)
-            except InvalidRequirement:
-                logger.warning(f"Invalid requirement format for package: {package}")
-                continue
-            new_or_updated.append(package_req)
-        return new_or_updated
+    # If no version toml file, add new package
+    if not bool(pip_versions_toml):
+        return PipDependency(requirement=package_req, no_version=no_version)
 
-    # If versions file exists, check if packages need to be updated
-    with open(versions_install_path, "rb") as f:
-        versions = tomllib.load(f)
-        versions = {k.lower(): v for k, v in versions.items()}
+    # Get installed version
+    installed_version = SpecifierSet(pip_versions_toml.get(package_req.name.lower()))
+    if installed_version is None:
+        installed_version = SpecifierSet(
+            f"=={_get_latest_pip_version(package_req.name)}"
+        )
+        logger.info(
+            f"Using latest version for {package_req.name}: {str(installed_version)}"
+        )
 
-    for package in pip_packages:
-        try:
-            processed_package = preprocess_requirement(package)
-            package_req = Requirement(processed_package)
-        except InvalidRequirement:
-            logger.warning(f"Invalid requirement format for package: {package}")
-            continue
+    # If version number match requirement, package doesn't need to be updated
+    if installed_version == package_req.specifier:
+        logger.info(
+            f"Package {package_req.name} is already installed at version {installed_version}"
+        )
+        return None
 
-        package_name = package_req.name
+    # If version number doesn't match requirement, package needs to be updated
+    logger.info(f"Package {package_req.name} needs to be updated")
+    return PipDependency(requirement=package_req, no_version=no_version)
 
-        installed_version = versions.get(package_name.lower())
-        if installed_version is None:
-            new_or_updated.append(package_req)
-            logger.info(f"Package {package_name} not installed")
-            continue
 
-        # Extract version number
-        version_pattern = re.compile(r"^([\w.-]+)(?:(==|>=|<=|!=|~=|>|<)(.+))?$")
-        match = version_pattern.match(installed_version)
-        version_operator = match.group(2)
-        version_number = match.group(3)
+def _get_latest_pip_version(package_name: str) -> str:
+    url = f"https://pypi.org/pypi/{package_name}/json"
+    response = requests.get(url)
+    if response.status_code == 200:
+        return response.json()["info"]["version"]
 
-        # If version number doesn't match requirement, package needs to be updated
-        if version_number is not None:
-            # Convert version number to a SpecifierSet and compare with requirement
-            installed_specifier = f"{version_operator}{version_number}"
-            if SpecifierSet(installed_specifier) != package_req.specifier:
-                new_or_updated.append(package_req)
-                logger.info(f"Package {package_name} needs to be updated")
-        else:
-            if package_req.specifier is not None:
-                new_or_updated.append(package_req)
-                logger.info(f"Package {package_name} needs to be updated")
-
-    return new_or_updated
+    raise ValueError(f"Unable to determine latest version for {package_name}")
 
 
 # ------------------------------------------------------------------
@@ -147,6 +179,7 @@ class GitHubDependency:
     repo: str
     version: str | None = None
     headers: dict | None = None
+    no_version: bool = False
 
     @classmethod
     def from_string(cls, dep_string: str) -> "GitHubDependency":
@@ -176,59 +209,60 @@ class GitHubDependency:
         return self.format_no_version()
 
 
-def get_new_or_updated_github_dependencies(
-    github_ids: list[str], base_install_path: Path
-):
+def _get_new_or_updated_github_dependency(
+    package: str, github_versions_toml: dict[str, str]
+) -> GitHubDependency | None:
     """Return a list of new or updated GitHub dependencies.
 
-    :param github_ids: List of GitHub dependency IDs
-    :type github_ids: list[str]
-    :param base_install_path: Base install path
-    :type base_install_path: Path
+    :param package: Package ID
+    :type package: str
+    :param github_versions_toml: Dictionary of GitHub versions
+    :type github_versions_toml: dict[str, str]
     :return: List of new or updated GitHub dependencies
     :rtype: list[str]
     """
-    new_or_updated = []
-    for package_id in github_ids:
-        github_dependency = GitHubDependency.from_string(package_id)
+    github_dependency = GitHubDependency.from_string(package)
 
-        headers = REQUEST_HEADERS.copy()
-        headers.update(_maybe_retrieve_github_auth())
+    headers = REQUEST_HEADERS.copy()
+    headers.update(_maybe_retrieve_github_auth())
 
-        if github_dependency.headers is None:
-            github_dependency.headers = headers
+    if github_dependency.headers is None:
+        github_dependency.headers = headers
 
-        if github_dependency.version is None:
-            github_dependency.version = _get_latest_github_version(
-                github_dependency.org, github_dependency.repo, github_dependency.headers
-            )
-            logger.info(
-                f"Using latest version for {github_dependency.org}/{github_dependency.repo}: {github_dependency.version}"
-            )
+    if github_dependency.version is None:
+        github_dependency.no_version = True
+        github_dependency.version = _get_latest_github_version(
+            github_dependency.org, github_dependency.repo, github_dependency.headers
+        )
+        logger.info(
+            f"Using latest version for {github_dependency.org}/{github_dependency.repo}: {github_dependency.version}"
+        )
 
-        versions_install_path = base_install_path.joinpath(PACKAGE_VERSION_FILE)
-        if versions_install_path.exists():
-            with open(versions_install_path, "rb") as f:
-                versions = tomllib.load(f)
-                versions = {k.lower(): v for k, v in versions.items()}
-                installed_version = versions.get(
-                    f"{github_dependency.org}/{github_dependency.repo}", None
-                )
-            if installed_version == github_dependency.version:
-                logger.info(
-                    f"{github_dependency.org}/{github_dependency.repo} already installed at version {github_dependency.version}"
-                )
-                continue
-            else:
-                logger.info(
-                    f"{github_dependency.org}/{github_dependency.repo} needs to be updated from version {installed_version} to {github_dependency.version}"
-                )
-                new_or_updated.append(github_dependency)
-        else:
-            # If versions file doesn't exist, all packages need to be installed
-            new_or_updated.append(github_dependency)
+    if not bool(github_versions_toml):
+        return github_dependency
 
-    return new_or_updated
+    installed_version = github_versions_toml.get(
+        f"{github_dependency.org}/{github_dependency.repo}", None
+    )
+
+    if installed_version is None:
+        installed_version = _get_latest_github_version(
+            github_dependency.org, github_dependency.repo, github_dependency.headers
+        )
+        logger.info(
+            f"Using latest version for {github_dependency.org}/{github_dependency.repo}: {installed_version}"
+        )
+
+    if installed_version == github_dependency.version:
+        logger.info(
+            f"{github_dependency.org}/{github_dependency.repo} already installed at version {github_dependency.version}"
+        )
+        return None
+
+    logger.info(
+        f"{github_dependency.org}/{github_dependency.repo} needs to be updated from version {installed_version} to {github_dependency.version}"
+    )
+    return github_dependency
 
 
 def _maybe_retrieve_github_auth() -> dict[str, str]:
@@ -265,7 +299,7 @@ def _get_latest_github_version(org: str, repo: str, headers: dict) -> str:
 #                        WRITE DEPENDENCIES
 # ------------------------------------------------------------------
 def add_dependency_to_versions_file(
-    versions_install_path: Path, dependency: GitHubDependency | Requirement
+    versions_install_path: Path, dependency: GitHubDependency | PipDependency
 ):
     # Update versions file
     if versions_install_path.exists():
@@ -274,7 +308,9 @@ def add_dependency_to_versions_file(
         if isinstance(dependency, GitHubDependency):
             versions_data[f"{dependency.org}/{dependency.repo}"] = dependency.version
         else:
-            versions_data[f"{dependency.name}"] = str(dependency)
+            versions_data[f"{dependency.requirement.name}"] = str(
+                dependency.requirement.specifier
+            )
 
         with open(versions_install_path, "wb") as f:
             tomli_w.dump(versions_data, f)
@@ -285,12 +321,14 @@ def add_dependency_to_versions_file(
                     {f"{dependency.org}/{dependency.repo}": dependency.version}
                 )
             else:
-                toml_string = tomli_w.dumps({dependency.name: str(dependency)})
+                toml_string = tomli_w.dumps(
+                    {dependency.requirement.name: str(dependency.requirement.specifier)}
+                )
             f.write(toml_string)
 
 
 def write_new_config_dependencies(
-    new_package_ids: list[GitHubDependency | Requirement],
+    new_packages: list[GitHubDependency | PipDependency],
     dependency_type: DependencyType,
 ):
     config = get_or_initialize_config()
@@ -306,19 +344,19 @@ def write_new_config_dependencies(
     updated_packages = set()
 
     if dependency_type == DependencyType.PIP:
-        for package_req in new_package_ids:
+        for pip_dependency in new_packages:
             for dep in typed_dependencies:
                 dep_req = Requirement(dep)
-                if dep_req.name == package_req.name:
+                if dep_req.name.lower() == pip_dependency.requirement.name.lower():
                     to_delete.add(dep)
-                    updated_packages.add(package_req.name)
+                    updated_packages.add(pip_dependency.requirement.name)
 
-            if package_req.name not in updated_packages:
-                logger.info(f"Installed new package: {str(package_req)}")
+            if pip_dependency.requirement.name not in updated_packages:
+                logger.info(f"Installed new package: {str(pip_dependency.requirement)}")
             else:
-                logger.info(f"Updated package: {str(package_req)}")
+                logger.info(f"Updated package: {str(pip_dependency.requirement)}")
     else:  # GIT dependencies
-        for package_dep in new_package_ids:
+        for package_dep in new_packages:
             for dep in typed_dependencies:
                 dep_gh = GitHubDependency.from_string(dep)
                 if dep_gh.org == package_dep.org and dep_gh.repo == package_dep.repo:
@@ -333,12 +371,22 @@ def write_new_config_dependencies(
     # Remove old versions of updated packages
     dependencies = [dep for dep in dependencies if dep not in to_delete]
 
+    # Get new packgages name and version if not latest
+    formated_new_packages: list[str] = []
+    for package in new_packages:
+        if package.no_version:
+            if dependency_type == DependencyType.PIP:
+                formated_new_packages.append(package.requirement.name)
+            else:
+                formated_new_packages.append(package.format_no_version())
+        else:
+            formated_new_packages.append(str(package))
+
     # Add new packages while preserving order
     new_deps = []
-    # @dev Could be better here maybe
-    for dep in dependencies + [str(package) for package in new_package_ids]:
+    for dep in dependencies + formated_new_packages:
         if dep not in new_deps:
-            new_deps.append(dep)
+            new_deps.append(dep.lower())
 
     if len(new_deps) > 0:
         config.write_dependencies(new_deps)

--- a/moccasin/_dependency_utils.py
+++ b/moccasin/_dependency_utils.py
@@ -496,6 +496,7 @@ def write_dependency_to_versions_file(
     :type dependency: GitHubDependency | PipDependency
     """
     if versions_install_path.exists():
+        versions_data: dict[str, str] = {}
         with open(versions_install_path, "rb") as f:
             versions_data = tomllib.load(f)
         if isinstance(dependency, GitHubDependency):
@@ -504,11 +505,11 @@ def write_dependency_to_versions_file(
             versions_data[f"{dependency.requirement.name.lower()}"] = str(
                 dependency.requirement.specifier
             )
-
         with open(versions_install_path, "wb") as f:
             tomli_w.dump(versions_data, f)
     else:
         with open(versions_install_path, "w", encoding="utf-8") as f:
+            toml_string: str
             if isinstance(dependency, GitHubDependency):
                 toml_string = tomli_w.dumps(
                     {f"{dependency.org}/{dependency.repo}": dependency.version}

--- a/moccasin/commands/_install_utils.py
+++ b/moccasin/commands/_install_utils.py
@@ -10,7 +10,9 @@ def check_mox_install(args: Namespace) -> None:
     :param args: Command line arguments
     :type args: Namespace
     """
-    if hasattr(args, "no_install") and not args.no_install:
+    if not hasattr(args, "no_install") or (
+        hasattr(args, "no_install") and not args.no_install
+    ):
         init_quiet: bool | None = args.quiet if hasattr(args, "quiet") else None
         # Force/add quiet arg for install
         args.quiet = True

--- a/moccasin/commands/_install_utils.py
+++ b/moccasin/commands/_install_utils.py
@@ -1,0 +1,23 @@
+from argparse import Namespace
+
+from moccasin.commands.install import mox_install
+
+
+def check_mox_install(args: Namespace) -> None:
+    """
+    Check if mox install needs to be run.
+
+    :param args: Command line arguments
+    :type args: Namespace
+    """
+    if hasattr(args, "no_install") and not args.no_install:
+        init_quiet: bool | None = args.quiet if hasattr(args, "quiet") else None
+        # Force/add quiet arg for install
+        args.quiet = True
+        mox_install(args)
+        # Remove quiet arg if it was set before install
+        # @dev args namespace are mutable
+        if init_quiet is not None:
+            args.quiet = init_quiet
+        else:
+            del args.quiet

--- a/moccasin/commands/compile.py
+++ b/moccasin/commands/compile.py
@@ -24,8 +24,7 @@ from moccasin.constants.vars import (
     MOCCASIN_GITHUB,
 )
 from moccasin.logging import logger
-
-from .install import mox_install
+from moccasin.commands.install import mox_install
 
 
 def main(args: Namespace) -> int:

--- a/moccasin/commands/compile.py
+++ b/moccasin/commands/compile.py
@@ -15,7 +15,7 @@ from vyper.compiler.phases import CompilerData
 from vyper.exceptions import VersionException, _BaseVyperException
 
 from moccasin._sys_path_and_config_setup import _patch_sys_path, get_sys_paths_list
-from moccasin.config import Config, get_config, initialize_global_config
+from moccasin.config import Config, get_config, get_or_initialize_config
 from moccasin.constants.vars import (
     BUILD_FOLDER,
     CONTRACTS_FOLDER,
@@ -25,9 +25,14 @@ from moccasin.constants.vars import (
 )
 from moccasin.logging import logger
 
+from .install import mox_install
+
 
 def main(args: Namespace) -> int:
-    config = initialize_global_config()
+    if not args.no_install:
+        mox_install(args)
+
+    config = get_or_initialize_config()
     project_path: Path = config.get_root()
 
     is_zksync: bool = _set_zksync_test_env_if_applicable(args, config)

--- a/moccasin/commands/deploy.py
+++ b/moccasin/commands/deploy.py
@@ -5,12 +5,16 @@ from moccasin._sys_path_and_config_setup import (
     _setup_network_and_account_from_config_and_cli,
     get_sys_paths_list,
 )
+from moccasin.commands._install_utils import check_mox_install
 from moccasin.config import get_config, initialize_global_config
 from moccasin.logging import logger
 
 
 def main(args: Namespace) -> int:
     config = initialize_global_config()
+
+    # Install if needed
+    check_mox_install(args)
 
     # Set up the environment (add necessary paths to sys.path, etc.)
     with _patch_sys_path(get_sys_paths_list(config)):

--- a/moccasin/commands/install.py
+++ b/moccasin/commands/install.py
@@ -26,7 +26,18 @@ from moccasin.constants.vars import GITHUB, PACKAGE_VERSION_FILE, PYPI, REQUEST_
 from moccasin.logging import logger
 
 
-def main(args: Namespace):
+def main(args: Namespace) -> int:
+    return mox_install(args)
+
+
+def mox_install(args: Namespace) -> int:
+    """Install the given requirements from PyPI and GitHub.
+
+    :param args: Namespace Requirements to install
+    :type args: Namespace
+    :return: int 0 at the end of the function
+    :rtype: int
+    """
     requirements = args.requirements
     config = get_or_initialize_config()
     if len(requirements) == 0:

--- a/moccasin/commands/install.py
+++ b/moccasin/commands/install.py
@@ -99,9 +99,6 @@ def mox_install(args: Namespace | None = None) -> int:
         requirements_dict, pip_install_path, github_install_path, update_packages
     )
 
-    logger.info(f"Pip new or updated: {pip_new_or_updated}")
-    logger.info(f"Github new or updated: {github_new_or_updated}")
-
     # Pip installs
     if len(pip_new_or_updated) > 0:
         _pip_installs(pip_new_or_updated, pip_install_path, quiet)

--- a/moccasin/commands/install.py
+++ b/moccasin/commands/install.py
@@ -6,19 +6,19 @@ import traceback
 import zipfile
 from argparse import Namespace
 from io import BytesIO
-from packaging.requirements import Requirement
 from pathlib import Path
 from urllib.parse import quote
 
 import requests  # type: ignore
+from packaging.requirements import Requirement
 from tqdm import tqdm
 
 from moccasin._dependency_utils import (
     DependencyType,
     GitHubDependency,
     add_dependency_to_versions_file,
-    write_new_config_dependencies,
     get_new_or_updated_dependencies,
+    write_new_config_dependencies,
 )
 from moccasin.config import get_or_initialize_config
 from moccasin.constants.vars import GITHUB, PACKAGE_VERSION_FILE, PYPI, REQUEST_HEADERS

--- a/moccasin/commands/install.py
+++ b/moccasin/commands/install.py
@@ -16,13 +16,13 @@ from tqdm import tqdm
 from moccasin._dependency_utils import (
     DependencyType,
     GitHubDependency,
-    write_dependency_to_versions_file,
     get_new_or_updated_dependencies,
+    write_dependency_to_versions_file,
     write_new_config_dependencies,
 )
 from moccasin.config import get_or_initialize_config
 from moccasin.constants.vars import GITHUB, PACKAGE_VERSION_FILE, PYPI, REQUEST_HEADERS
-from moccasin.logging import logger
+from moccasin.logging import logger, set_log_level
 
 
 def main(args: Namespace) -> int:
@@ -69,8 +69,9 @@ def mox_install(args: Namespace | None = None) -> int:
         args.requirements if args is not None and hasattr(args, "requirements") else []
     )
 
-    # Get quiet flag
+    # Get quiet flag and set log level
     quiet = args.quiet if hasattr(args, "quiet") else False
+    set_log_level(quiet=quiet)
 
     # Get pip and github requirements
     logger.info("Checking for new or to update packages...")
@@ -90,6 +91,9 @@ def mox_install(args: Namespace | None = None) -> int:
         _github_installs(github_new_or_updated, github_install_path)
     else:
         logger.info("No GitHub packages to install")
+
+    # Reset log level
+    set_log_level()
     return 0
 
 

--- a/moccasin/commands/install.py
+++ b/moccasin/commands/install.py
@@ -16,7 +16,7 @@ from tqdm import tqdm
 from moccasin._dependency_utils import (
     DependencyType,
     GitHubDependency,
-    add_dependency_to_versions_file,
+    write_dependency_to_versions_file,
     get_new_or_updated_dependencies,
     write_new_config_dependencies,
 )
@@ -139,7 +139,7 @@ def _pip_installs(
     versions_install_path = base_install_path.joinpath(PACKAGE_VERSION_FILE)
     # @dev Could be better here maybe
     for package in new_pip_packages:
-        add_dependency_to_versions_file(versions_install_path, package)
+        write_dependency_to_versions_file(versions_install_path, package)
 
     write_new_config_dependencies(new_pip_packages, DependencyType.PIP)
 
@@ -213,7 +213,7 @@ def _github_installs(
             shutil.move(installed, repo_install_path)
 
         # Update versions file
-        add_dependency_to_versions_file(versions_install_path, github_dependency)
+        write_dependency_to_versions_file(versions_install_path, github_dependency)
 
     write_new_config_dependencies(github_new_or_updated, DependencyType.GITHUB)
 

--- a/moccasin/commands/install.py
+++ b/moccasin/commands/install.py
@@ -14,7 +14,6 @@ from packaging.requirements import Requirement
 from tqdm import tqdm
 
 from moccasin._dependency_utils import (
-    DependencyType,
     GitHubDependency,
     get_new_or_updated_dependencies,
     parse_and_convert_dependencies,
@@ -112,6 +111,9 @@ def mox_install(args: Namespace | None = None) -> int:
     else:
         logger.info("No GitHub packages to install")
 
+    # Write new config dependencies
+    write_new_config_dependencies(pip_new_or_updated, github_new_or_updated)
+
     # Reset log level
     set_log_level()
     return 0
@@ -164,8 +166,6 @@ def _pip_installs(
     # @dev Could be better here maybe
     for package in new_pip_packages:
         write_dependency_to_versions_file(versions_install_path, package)
-
-    write_new_config_dependencies(new_pip_packages, DependencyType.PIP)
 
 
 # ------------------------------------------------------------------
@@ -239,7 +239,7 @@ def _github_installs(
         # Update versions file
         write_dependency_to_versions_file(versions_install_path, github_dependency)
 
-    write_new_config_dependencies(github_new_or_updated, DependencyType.GITHUB)
+    return github_new_or_updated
 
 
 def _stream_download(

--- a/moccasin/commands/run.py
+++ b/moccasin/commands/run.py
@@ -7,15 +7,13 @@ from moccasin._sys_path_and_config_setup import (
     _setup_network_and_account_from_config_and_cli,
     get_sys_paths_list,
 )
+from moccasin.commands._install_utils import check_mox_install
 from moccasin.config import get_config, get_or_initialize_config
 from moccasin.logging import logger
 
-from moccasin.commands.install import mox_install
-
 
 def main(args: Namespace) -> int:
-    if not args.no_install:
-        mox_install(args)
+    check_mox_install(args)
 
     get_or_initialize_config()
     run_script(

--- a/moccasin/commands/run.py
+++ b/moccasin/commands/run.py
@@ -7,12 +7,17 @@ from moccasin._sys_path_and_config_setup import (
     _setup_network_and_account_from_config_and_cli,
     get_sys_paths_list,
 )
-from moccasin.config import get_config, initialize_global_config
+from moccasin.config import get_config, get_or_initialize_config
 from moccasin.logging import logger
+
+from .install import mox_install
 
 
 def main(args: Namespace) -> int:
-    initialize_global_config()
+    if not args.no_install:
+        mox_install(args)
+
+    get_or_initialize_config()
     run_script(
         args.script_name_or_path,
         network=args.network,

--- a/moccasin/commands/run.py
+++ b/moccasin/commands/run.py
@@ -10,7 +10,7 @@ from moccasin._sys_path_and_config_setup import (
 from moccasin.config import get_config, get_or_initialize_config
 from moccasin.logging import logger
 
-from .install import mox_install
+from moccasin.commands.install import mox_install
 
 
 def main(args: Namespace) -> int:

--- a/moccasin/commands/test.py
+++ b/moccasin/commands/test.py
@@ -12,6 +12,7 @@ from moccasin._sys_path_and_config_setup import (
     _setup_network_and_account_from_config_and_cli,
     get_sys_paths_list,
 )
+from moccasin.commands._install_utils import check_mox_install
 from moccasin.config import Config, get_config, initialize_global_config
 from moccasin.constants.vars import TESTS_FOLDER
 
@@ -51,6 +52,9 @@ PYTEST_ARGS: list[str] = [
 def main(args: Namespace) -> int:
     initialize_global_config()
     pytest_args = []
+
+    # Install if needed
+    check_mox_install(args)
 
     # This is not in PYTEST_ARGS
     if "coverage" in args and args.coverage:

--- a/tests/cli/test_cli_compile.py
+++ b/tests/cli/test_cli_compile.py
@@ -2,7 +2,7 @@ import os
 import subprocess
 from pathlib import Path
 
-from tests.constants import LIB_PIP_PATH, LIB_GH_PATH
+from tests.constants import LIB_GH_PATH, LIB_PIP_PATH
 
 EXPECTED_HELP_TEXT = "Vyper compiler"
 

--- a/tests/cli/test_cli_compile.py
+++ b/tests/cli/test_cli_compile.py
@@ -2,6 +2,8 @@ import os
 import subprocess
 from pathlib import Path
 
+from tests.constants import LIB_PIP_PATH, LIB_GH_PATH
+
 EXPECTED_HELP_TEXT = "Vyper compiler"
 
 
@@ -9,9 +11,9 @@ def test_compile_help(mox_path):
     result = subprocess.run(
         [mox_path, "compile", "-h"], check=True, capture_output=True, text=True
     )
-    assert (
-        EXPECTED_HELP_TEXT in result.stdout
-    ), "Help output does not contain expected text"
+    assert EXPECTED_HELP_TEXT in result.stdout, (
+        "Help output does not contain expected text"
+    )
     assert result.returncode == 0
 
 
@@ -19,14 +21,14 @@ def test_build_help(mox_path):
     result = subprocess.run(
         [mox_path, "build", "-h"], check=True, capture_output=True, text=True
     )
-    assert (
-        EXPECTED_HELP_TEXT in result.stdout
-    ), "Help output does not contain expected text"
+    assert EXPECTED_HELP_TEXT in result.stdout, (
+        "Help output does not contain expected text"
+    )
     assert result.returncode == 0
 
 
 def test_compile_alias_build_project(
-    complex_temp_path, complex_cleanup_out_folder, mox_path
+    complex_temp_path, complex_cleanup_dependencies_folder, mox_path
 ):
     current_dir = Path.cwd()
     try:
@@ -36,7 +38,24 @@ def test_compile_alias_build_project(
         )
     finally:
         os.chdir(current_dir)
+
+    # Count the number of contracts in the contracts/ directory
+    # @dev avoid interfaces folder
+    contract_dir = complex_temp_path.joinpath("contracts")
+    contract_count = sum(
+        [
+            len(files)
+            for root, _, files in os.walk(contract_dir)
+            if "interfaces" not in root
+        ]
+    )
+
+    assert "Installing 1 pip packages..." in result.stderr
+    assert complex_temp_path.joinpath(LIB_PIP_PATH).exists()
+
     assert "Running compile command" in result.stderr
+    assert f"Compiling {contract_count} contracts to build/..." in result.stderr
+    assert "Done compiling project!" in result.stderr
     assert result.returncode == 0
 
 
@@ -45,12 +64,16 @@ def test_compile_one(complex_temp_path, complex_cleanup_out_folder, mox_path):
     try:
         os.chdir(current_dir.joinpath(complex_temp_path))
         result = subprocess.run(
-            [mox_path, "build", "BuyMeACoffee.vy"],
+            [mox_path, "build", "BuyMeACoffee.vy", "--no-install"],
             check=True,
             capture_output=True,
             text=True,
         )
     finally:
         os.chdir(current_dir)
+
+    assert not complex_temp_path.joinpath(LIB_GH_PATH).exists()
+    assert not complex_temp_path.joinpath(LIB_PIP_PATH).exists()
+
     assert "Done compiling BuyMeACoffee" in result.stderr
     assert result.returncode == 0

--- a/tests/cli/test_cli_compile.py
+++ b/tests/cli/test_cli_compile.py
@@ -50,7 +50,6 @@ def test_compile_alias_build_project(
         ]
     )
 
-    assert "Installing 1 pip packages..." in result.stderr
     assert complex_temp_path.joinpath(LIB_PIP_PATH).exists()
 
     assert "Running compile command" in result.stderr

--- a/tests/cli/test_cli_compile.py
+++ b/tests/cli/test_cli_compile.py
@@ -2,6 +2,7 @@ import os
 import subprocess
 from pathlib import Path
 
+import pytest
 import tomli_w
 
 from moccasin.config import Config
@@ -12,6 +13,7 @@ from tests.constants import (
     NEW_VERSION,
     PATRICK_PACKAGE_NAME,
     PIP_PACKAGE_NAME,
+    VERSION,
 )
 from tests.utils.helpers import (
     get_temp_versions_toml_from_libs,
@@ -92,52 +94,61 @@ def test_compile_one(complex_temp_path, complex_cleanup_out_folder, mox_path):
     assert result.returncode == 0
 
 
-def test_compile_and_update(complex_temp_path, complex_cleanup_out_folder, mox_path):
+@pytest.mark.parametrize(
+    "cli_args, expect_gh_path, expect_pip_path, expect_pip_version, expect_gh_package, dependencies",
+    [
+        # --no-install should skip package installation
+        (["--no-install"], False, False, f"=={VERSION}", False, []),
+        # Default behavior - installs dependencies
+        ([], False, True, f"=={VERSION}", False, []),
+        # --update-packages should update existing dependencies
+        (["--update-packages"], True, True, f"=={NEW_VERSION}", True, None),
+    ],
+)
+def test_compile_with_flags(
+    complex_temp_path,
+    complex_cleanup_dependencies_folder,
+    mox_path,
+    cli_args,
+    expect_gh_path,
+    expect_pip_path,
+    expect_pip_version,
+    expect_gh_package,
+    dependencies,
+):
     current_dir = Path.cwd()
+    if dependencies is not None:
+        old_moccasin_toml = rewrite_temp_moccasin_toml_dependencies(
+            complex_temp_path, dependencies
+        )
+    else:
+        old_moccasin_toml = rewrite_temp_moccasin_toml_dependencies(complex_temp_path)
+
     try:
         os.chdir(current_dir.joinpath(complex_temp_path))
+        base_args = [mox_path, "build", "BuyMeACoffee.vy"]
         result = subprocess.run(
-            [mox_path, "build", "BuyMeACoffee.vy"],
-            check=True,
-            capture_output=True,
-            text=True,
+            base_args + cli_args, check=True, capture_output=True, text=True
         )
     finally:
         os.chdir(current_dir)
 
-    assert not complex_temp_path.joinpath(LIB_GH_PATH).exists()
-    assert complex_temp_path.joinpath(LIB_PIP_PATH).exists()
-    assert "Done compiling BuyMeACoffee" in result.stderr
-    assert result.returncode == 0
+    assert complex_temp_path.joinpath(LIB_GH_PATH).exists() == expect_gh_path
+    assert complex_temp_path.joinpath(LIB_PIP_PATH).exists() == expect_pip_path
 
-    # Second run should update the version in the config
-    old_moccasin_toml = rewrite_temp_moccasin_toml_dependencies(complex_temp_path)
-
-    try:
-        os.chdir(current_dir.joinpath(complex_temp_path))
-        result_two = subprocess.run(
-            [mox_path, "build", "BuyMeACoffee.vy", "--update-packages"],
-            check=True,
-            capture_output=True,
-            text=True,
-        )
-    finally:
-        os.chdir(current_dir)
-
-    assert complex_temp_path.joinpath(LIB_GH_PATH).exists()
-    assert complex_temp_path.joinpath(LIB_PIP_PATH).exists()
-
+    # Verify config state if versions are expected
     project_root: Path = Config.find_project_root(complex_temp_path)
     config = Config(project_root)
-    assert f"{PIP_PACKAGE_NAME}=={NEW_VERSION}" in config.dependencies
-    assert f"{PATRICK_PACKAGE_NAME}" in config.dependencies
-
     github_versions, pip_versions = get_temp_versions_toml_from_libs(complex_temp_path)
-    assert github_versions[f"{PATRICK_PACKAGE_NAME}"] == "0.1.1"
-    assert pip_versions[f"{PIP_PACKAGE_NAME}"] == f"=={NEW_VERSION}"
+    assert f"{PIP_PACKAGE_NAME}{expect_pip_version}" in config.dependencies
+    if expect_pip_path and expect_pip_version:
+        assert pip_versions[f"{PIP_PACKAGE_NAME}"] == expect_pip_version
+    if expect_gh_path and expect_gh_package:
+        assert PATRICK_PACKAGE_NAME in config.dependencies
+        assert github_versions[f"{PATRICK_PACKAGE_NAME}"] == "0.1.1"
 
-    assert "Done compiling BuyMeACoffee" in result_two.stderr
-    assert result_two.returncode == 0
+    assert "Done compiling BuyMeACoffee" in result.stderr
+    assert result.returncode == 0
 
     # Reset toml to the original for next test
     with open(complex_temp_path.joinpath(MOCCASIN_TOML), "wb") as f:

--- a/tests/cli/test_cli_deploy.py
+++ b/tests/cli/test_cli_deploy.py
@@ -2,6 +2,22 @@ import os
 import subprocess
 from pathlib import Path
 
+import tomli_w
+
+from moccasin.config import Config
+from tests.constants import (
+    LIB_GH_PATH,
+    LIB_PIP_PATH,
+    MOCCASIN_TOML,
+    NEW_VERSION,
+    PATRICK_PACKAGE_NAME,
+    PIP_PACKAGE_NAME,
+)
+from tests.utils.helpers import (
+    get_temp_versions_toml_from_libs,
+    rewrite_temp_moccasin_toml_dependencies,
+)
+
 
 # --------------------------------------------------------------
 #                         WITHOUT ANVIL
@@ -19,6 +35,56 @@ def test_deploy_price_feed_pyevm(mox_path, complex_temp_path, complex_project_co
     finally:
         os.chdir(current_dir)
     assert "Deployed contract price_feed on pyevm to" in result.stderr
+
+
+def test_deploy_price_feed_pyevm_and_update(
+    mox_path, complex_temp_path, complex_project_config
+):
+    current_dir = Path.cwd()
+    try:
+        os.chdir(complex_temp_path)
+        result = subprocess.run(
+            [mox_path, "deploy", "price_feed"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    finally:
+        os.chdir(current_dir)
+    assert "Deployed contract price_feed on pyevm to" in result.stderr
+
+    # Second run should update the version in the config
+    old_moccasin_toml = rewrite_temp_moccasin_toml_dependencies(complex_temp_path)
+
+    try:
+        os.chdir(complex_temp_path)
+        result_two = subprocess.run(
+            [mox_path, "deploy", "price_feed", "--update-packages"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    finally:
+        os.chdir(current_dir)
+
+    assert complex_temp_path.joinpath(LIB_PIP_PATH).exists()
+    assert complex_temp_path.joinpath(LIB_GH_PATH).exists()
+
+    project_root: Path = Config.find_project_root(complex_temp_path)
+    config = Config(project_root)
+    assert f"{PIP_PACKAGE_NAME}=={NEW_VERSION}" in config.dependencies
+    assert f"{PATRICK_PACKAGE_NAME}" in config.dependencies
+
+    github_versions, pip_versions = get_temp_versions_toml_from_libs(complex_temp_path)
+    assert github_versions[f"{PATRICK_PACKAGE_NAME}"] == "0.1.1"
+    assert pip_versions[f"{PIP_PACKAGE_NAME}"] == f"=={NEW_VERSION}"
+
+    # Check for the error message in the output
+    assert "Deployed contract price_feed on pyevm to" in result_two.stderr
+
+    # Reset toml to the original for next test
+    with open(complex_temp_path.joinpath(MOCCASIN_TOML), "wb") as f:
+        tomli_w.dump(old_moccasin_toml, f)
 
 
 # --------------------------------------------------------------

--- a/tests/cli/test_cli_inspect.py
+++ b/tests/cli/test_cli_inspect.py
@@ -5,17 +5,23 @@ from pathlib import Path
 from moccasin.commands.inspect import inspect_contract
 
 
-def test_inspect_layout_imports(mox_path, installation_project_config, installation_temp_path):
+def test_inspect_layout_imports(
+    mox_path, installation_project_config, installation_temp_path
+):
     current_dir = Path.cwd()
     try:
         os.chdir(current_dir.joinpath(installation_temp_path))
         result = subprocess.run(
-            [mox_path, "install"], check=True, capture_output=True, text=True
+            [mox_path, "install"], check=True, capture_output=False, text=True
         )
         result = inspect_contract("MyToken", "storage_layout", print_out=False)
     finally:
         os.chdir(current_dir)
     layout = result["storage_layout"]
     # Spot check
-    assert layout["ow"]["owner"] == {'type': 'address', 'n_slots': 1, 'slot': 0}
-    assert layout["erc20"]["balanceOf"] == {'type': 'HashMap[address, uint256]', 'n_slots': 1, 'slot': 1}
+    assert layout["ow"]["owner"] == {"type": "address", "n_slots": 1, "slot": 0}
+    assert layout["erc20"]["balanceOf"] == {
+        "type": "HashMap[address, uint256]",
+        "n_slots": 1,
+        "slot": 1,
+    }

--- a/tests/cli/test_cli_inspect.py
+++ b/tests/cli/test_cli_inspect.py
@@ -12,7 +12,7 @@ def test_inspect_layout_imports(
     try:
         os.chdir(current_dir.joinpath(installation_temp_path))
         result = subprocess.run(
-            [mox_path, "install"], check=True, capture_output=False, text=True
+            [mox_path, "install"], check=True, capture_output=True, text=True
         )
         result = inspect_contract("MyToken", "storage_layout", print_out=False)
     finally:

--- a/tests/cli/test_cli_install.py
+++ b/tests/cli/test_cli_install.py
@@ -29,7 +29,10 @@ def test_run_help(mox_path, installation_temp_path):
 
 
 def test_run_install_no_dependencies(
-    mox_path, installation_cleanup_keep_pip_dependencies, installation_temp_path: Path
+    mox_path,
+    installation_cleanup_dependencies,
+    installation_temp_path: Path,
+    installation_remove_dependencies,
 ):
     current_dir = Path.cwd()
     try:
@@ -49,7 +52,10 @@ def test_run_install_no_dependencies(
 
 
 def test_run_install_only_pip_dependencies(
-    mox_path, installation_cleanup_keep_gh_dependencies, installation_temp_path: Path
+    mox_path,
+    installation_cleanup_dependencies,
+    installation_temp_path: Path,
+    installation_keep_pip_dependencies,
 ):
     current_dir = Path.cwd()
     try:
@@ -69,7 +75,10 @@ def test_run_install_only_pip_dependencies(
 
 
 def test_run_install_only_gh_dependencies(
-    mox_path, installation_cleanup_dependencies, installation_temp_path: Path
+    mox_path,
+    installation_cleanup_dependencies,
+    installation_temp_path: Path,
+    installation_keep_gh_dependencies,
 ):
     current_dir = Path.cwd()
     try:
@@ -102,11 +111,10 @@ def test_run_install(mox_path, installation_temp_path: Path):
     pip_dir_path = installation_temp_path.joinpath(LIB_PIP_PATH)
 
     assert "Installing 2 pip packages..." in result.stderr
-    assert "Installing 2 GitHub packages..." in result.stderr
+    assert "Installing 1 GitHub packages..." in result.stderr
     assert installation_temp_path.joinpath(MOCCASIN_TOML).exists()
 
     assert gh_dir_path.joinpath(PATRICK_PACKAGE_NAME).exists()
-    assert gh_dir_path.joinpath(GITHUB_PACKAGE_NAME).exists()
 
     assert pip_dir_path.joinpath(PIP_PACKAGE_NAME).exists()
     assert pip_dir_path.joinpath(MOCCASIN_LIB_NAME).exists()
@@ -116,15 +124,18 @@ def test_run_install(mox_path, installation_temp_path: Path):
 
 
 def test_run_install_update_pip_and_gh(
-    mox_path, installation_cleanup_dependencies, installation_temp_path: Path
+    mox_path,
+    installation_cleanup_dependencies,
+    installation_temp_path: Path,
+    installation_keep_full_dependencies,
 ):
     current_dir = Path.cwd()
     try:
         os.chdir(installation_temp_path)
         result = subprocess.run(
             [mox_path, "install", "snekmate==0.0.5", "pcaversaccio/snekmate@0.0.5"],
-            check=False,
-            capture_output=False,
+            check=True,
+            capture_output=True,
             text=True,
         )
     finally:
@@ -132,12 +143,11 @@ def test_run_install_update_pip_and_gh(
 
     gh_dir_path = installation_temp_path.joinpath(LIB_GH_PATH)
     pip_dir_path = installation_temp_path.joinpath(LIB_PIP_PATH)
+    gh_message = f"{GITHUB_PACKAGE_NAME} needs to be updated from version {VERSION} to {NEW_VERSION}"
+    pip_message = f"{PIP_PACKAGE_NAME} needs to be updated from version {VERSION} to {NEW_VERSION}"
 
-    assert (
-        f"{GITHUB_PACKAGE_NAME} needs to be updated from version {VERSION} to {NEW_VERSION}"
-        in result.stderr
-    )
-    assert f"{PIP_PACKAGE_NAME} needs to be updated" in result.stderr
+    assert gh_message in result.stderr
+    assert pip_message in result.stderr
     assert "Installing 1 GitHub packages..." in result.stderr
     assert "Installing 1 pip packages..." in result.stderr
     assert installation_temp_path.joinpath(MOCCASIN_TOML).exists()

--- a/tests/cli/test_cli_install.py
+++ b/tests/cli/test_cli_install.py
@@ -2,18 +2,23 @@ import os
 import subprocess
 from pathlib import Path
 
+import pytest
+
+from moccasin.config import Config
 from tests.constants import (
     GITHUB_PACKAGE_NAME,
     LIB_GH_PATH,
     LIB_PIP_PATH,
     MOCCASIN_LIB_NAME,
     MOCCASIN_TOML,
+    MOCCASIN_VERSION,
     NEW_VERSION,
     PATRICK_PACKAGE_NAME,
     PIP_PACKAGE_NAME,
     VERSION,
     VERSIONS_TOML,
 )
+from tests.utils.helpers import get_temp_versions_toml_from_libs
 
 
 def test_run_help(mox_path, installation_temp_path):
@@ -159,3 +164,79 @@ def test_run_install_update_pip_and_gh(
 
     assert gh_dir_path.joinpath(VERSIONS_TOML).exists()
     assert pip_dir_path.joinpath(VERSIONS_TOML).exists()
+
+
+@pytest.mark.parametrize(
+    "dependencies_to_add, expected_dependencies, expected_pip_versions, expected_gh_versions",
+    [
+        # Default moccasin.toml install
+        (
+            [],
+            ["snekmate", "moccasin", "patrickalphac/test_repo"],
+            {"snekmate": f"=={VERSION}", "moccasin": f"=={MOCCASIN_VERSION}"},
+            {"patrickalphac/test_repo": "0.1.1"},
+        ),
+        # Change pip specification
+        (
+            [f"{PIP_PACKAGE_NAME}>={VERSION}", f"{MOCCASIN_LIB_NAME}==0.3.6"],
+            [
+                f"{PIP_PACKAGE_NAME}>={VERSION}",
+                f"{MOCCASIN_LIB_NAME}==0.3.6",
+                "patrickalphac/test_repo",
+            ],
+            {"snekmate": f">={VERSION}", "moccasin": "==0.3.6"},
+            {"patrickalphac/test_repo": "0.1.1"},
+        ),
+        # Change gh specification
+        (
+            [f"{PATRICK_PACKAGE_NAME}@0.1.0"],
+            [
+                f"{PIP_PACKAGE_NAME}>={VERSION}",
+                f"{MOCCASIN_LIB_NAME}==0.3.6",
+                "patrickalphac/test_repo@0.1.0",
+            ],
+            {"snekmate": f">={VERSION}", "moccasin": "==0.3.6"},
+            {"patrickalphac/test_repo": "0.1.0"},
+        ),
+    ],
+)
+def test_run_multiple_install(
+    mox_path,
+    installation_temp_path: Path,
+    dependencies_to_add,
+    expected_dependencies,
+    expected_pip_versions,
+    expected_gh_versions,
+):
+    current_dir = Path.cwd()
+    try:
+        os.chdir(installation_temp_path)
+        base_command = [mox_path, "install"]
+        subprocess.run(
+            base_command + dependencies_to_add,
+            check=True,
+            capture_output=False,
+            text=True,
+        )
+    finally:
+        os.chdir(current_dir)
+
+    gh_dir_path = installation_temp_path.joinpath(LIB_GH_PATH)
+    pip_dir_path = installation_temp_path.joinpath(LIB_PIP_PATH)
+
+    assert installation_temp_path.joinpath(MOCCASIN_TOML).exists()
+    assert gh_dir_path.joinpath(PATRICK_PACKAGE_NAME).exists()
+    assert pip_dir_path.joinpath(PIP_PACKAGE_NAME).exists()
+    assert pip_dir_path.joinpath(MOCCASIN_LIB_NAME).exists()
+
+    # Verify config state if versions are expected
+    project_root: Path = Config.find_project_root(installation_temp_path)
+    config = Config(project_root)
+    assert config.dependencies == expected_dependencies
+
+    # Verify versions file contents
+    github_versions, pip_versions = get_temp_versions_toml_from_libs(
+        installation_temp_path
+    )
+    assert github_versions == expected_gh_versions
+    assert pip_versions == expected_pip_versions

--- a/tests/cli/test_cli_install.py
+++ b/tests/cli/test_cli_install.py
@@ -43,8 +43,7 @@ def test_run_install_no_dependencies(
     finally:
         os.chdir(current_dir)
 
-    assert "No pip packages to install" in result.stderr
-    assert "No GitHub packages to install" in result.stderr
+    assert "No packages to install." in result.stderr
 
     assert installation_temp_path.joinpath(MOCCASIN_TOML).exists()
     assert not installation_temp_path.joinpath(LIB_GH_PATH).exists()

--- a/tests/cli/test_cli_install.py
+++ b/tests/cli/test_cli_install.py
@@ -2,6 +2,15 @@ import os
 import subprocess
 from pathlib import Path
 
+from tests.constants import (
+    GITHUB_PACKAGE_NAME,
+    LIB_GH_PATH,
+    LIB_PIP_PATH,
+    MOCCASIN_LIB_NAME,
+    PATRICK_PACKAGE_NAME,
+    PIP_PACKAGE_NAME,
+)
+
 
 def test_run_help(mox_path, installation_cleanup_dependencies, installation_temp_path):
     current_dir = Path.cwd()
@@ -13,3 +22,36 @@ def test_run_help(mox_path, installation_cleanup_dependencies, installation_temp
     finally:
         os.chdir(current_dir)
     assert "Moccasin CLI install" in result.stdout
+
+
+def test_run_install(
+    mox_path, installation_cleanup_dependencies, installation_temp_path: Path
+):
+    current_dir = Path.cwd()
+    try:
+        os.chdir(installation_temp_path)
+        result = subprocess.run(
+            [mox_path, "install"], check=True, capture_output=True, text=True
+        )
+    finally:
+        os.chdir(current_dir)
+    print_statements = result.stderr.split("\n")
+
+    assert "Installing 2 pip packages..." in print_statements
+    assert "Installing 2 GitHub packages..." in print_statements
+    assert installation_temp_path.joinpath("moccasin.toml").exists()
+    assert installation_temp_path.joinpath(
+        f"{LIB_PIP_PATH}/{MOCCASIN_LIB_NAME}"
+    ).exists()
+    assert installation_temp_path.joinpath(
+        f"{LIB_PIP_PATH}/{PIP_PACKAGE_NAME}"
+    ).exists()
+    assert installation_temp_path.joinpath(
+        f"{LIB_GH_PATH}/{GITHUB_PACKAGE_NAME}"
+    ).exists()
+    assert installation_temp_path.joinpath(
+        f"{LIB_GH_PATH}/{PATRICK_PACKAGE_NAME}"
+    ).exists()
+
+
+# os.listdir(installation_temp_path.joinpath(LIB_GH_PATH))

--- a/tests/cli/test_cli_install.py
+++ b/tests/cli/test_cli_install.py
@@ -9,6 +9,7 @@ from tests.constants import (
     MOCCASIN_LIB_NAME,
     PATRICK_PACKAGE_NAME,
     PIP_PACKAGE_NAME,
+    VERSIONS_TOML,
 )
 
 
@@ -24,6 +25,24 @@ def test_run_help(mox_path, installation_cleanup_dependencies, installation_temp
     assert "Moccasin CLI install" in result.stdout
 
 
+def test_run_install_no_dependencies(mox_path, installation_temp_path: Path):
+    current_dir = Path.cwd()
+    try:
+        os.chdir(installation_temp_path)
+        result = subprocess.run(
+            [mox_path, "install"], check=True, capture_output=True, text=True
+        )
+    finally:
+        os.chdir(current_dir)
+    print_statements = result.stderr.split("\n")
+
+    breakpoint()
+
+    # assert "Installing 2 pip packages..." in print_statements
+    # assert "Installing 2 GitHub packages..." in print_statements
+    # assert installation_temp_path.joinpath("moccasin.toml").exists()
+
+
 def test_run_install(
     mox_path, installation_cleanup_dependencies, installation_temp_path: Path
 ):
@@ -37,21 +56,21 @@ def test_run_install(
         os.chdir(current_dir)
     print_statements = result.stderr.split("\n")
 
+    gh_dir_path = installation_temp_path.joinpath(LIB_GH_PATH)
+    pip_dir_path = installation_temp_path.joinpath(LIB_PIP_PATH)
+
     assert "Installing 2 pip packages..." in print_statements
     assert "Installing 2 GitHub packages..." in print_statements
     assert installation_temp_path.joinpath("moccasin.toml").exists()
-    assert installation_temp_path.joinpath(
-        f"{LIB_PIP_PATH}/{MOCCASIN_LIB_NAME}"
-    ).exists()
-    assert installation_temp_path.joinpath(
-        f"{LIB_PIP_PATH}/{PIP_PACKAGE_NAME}"
-    ).exists()
-    assert installation_temp_path.joinpath(
-        f"{LIB_GH_PATH}/{GITHUB_PACKAGE_NAME}"
-    ).exists()
-    assert installation_temp_path.joinpath(
-        f"{LIB_GH_PATH}/{PATRICK_PACKAGE_NAME}"
-    ).exists()
+
+    assert gh_dir_path.joinpath(PATRICK_PACKAGE_NAME).exists()
+    assert gh_dir_path.joinpath(GITHUB_PACKAGE_NAME).exists()
+
+    assert pip_dir_path.joinpath(PIP_PACKAGE_NAME).exists()
+    assert pip_dir_path.joinpath(MOCCASIN_LIB_NAME).exists()
+
+    assert gh_dir_path.joinpath(VERSIONS_TOML).exists()
+    assert pip_dir_path.joinpath(VERSIONS_TOML).exists()
 
 
 # os.listdir(installation_temp_path.joinpath(LIB_GH_PATH))

--- a/tests/cli/test_cli_run.py
+++ b/tests/cli/test_cli_run.py
@@ -35,7 +35,6 @@ def test_run_default(mox_path, complex_cleanup_dependencies_folder, complex_temp
     finally:
         os.chdir(current_dir)
 
-    assert "Installing 1 pip packages..." in result.stderr
     assert complex_temp_path.joinpath(LIB_PIP_PATH).exists()
     assert "Ending count:  1" in result.stdout
 

--- a/tests/cli/test_cli_run.py
+++ b/tests/cli/test_cli_run.py
@@ -6,6 +6,7 @@ from tests.constants import (
     ANVIL1_KEYSTORE_NAME,
     ANVIL1_KEYSTORE_PASSWORD,
     ANVIL1_PRIVATE_KEY,
+    LIB_PIP_PATH,
 )
 
 
@@ -24,7 +25,7 @@ def test_run_help(mox_path, complex_temp_path):
     assert "Moccasin CLI run" in result.stdout
 
 
-def test_run_default(mox_path, complex_temp_path):
+def test_run_default(mox_path, complex_cleanup_dependencies_folder, complex_temp_path):
     current_dir = Path.cwd()
     try:
         os.chdir(complex_temp_path)
@@ -33,6 +34,9 @@ def test_run_default(mox_path, complex_temp_path):
         )
     finally:
         os.chdir(current_dir)
+
+    assert "Installing 1 pip packages..." in result.stderr
+    assert complex_temp_path.joinpath(LIB_PIP_PATH).exists()
     assert "Ending count:  1" in result.stdout
 
 
@@ -41,7 +45,7 @@ def test_multiple_manifest_returns_the_same_or_different(mox_path, complex_temp_
     os.chdir(complex_temp_path)
     try:
         result = subprocess.run(
-            [mox_path, "run", "quad_manifest"],
+            [mox_path, "run", "quad_manifest", "--no-install"],
             check=True,
             capture_output=True,
             text=True,

--- a/tests/cli/test_cli_run.py
+++ b/tests/cli/test_cli_run.py
@@ -2,6 +2,7 @@ import os
 import subprocess
 from pathlib import Path
 
+import pytest
 import tomli_w
 
 from moccasin.config import Config
@@ -15,6 +16,7 @@ from tests.constants import (
     NEW_VERSION,
     PATRICK_PACKAGE_NAME,
     PIP_PACKAGE_NAME,
+    VERSION,
 )
 from tests.utils.helpers import (
     get_temp_versions_toml_from_libs,
@@ -51,9 +53,67 @@ def test_run_default(mox_path, complex_cleanup_dependencies_folder, complex_temp
     assert "Ending count:  1" in result.stdout
 
 
-def test_run_default_and_update(
-    complex_temp_path, complex_cleanup_out_folder, mox_path
+@pytest.mark.parametrize(
+    "cli_args, expect_gh_path, expect_pip_path, expect_pip_version, expect_gh_package, dependencies",
+    [
+        # --no-install should skip package installation
+        (["--no-install"], False, False, f"=={VERSION}", False, []),
+        # Default behavior - installs dependencies
+        ([], False, True, f"=={VERSION}", False, []),
+        # --update-packages should update existing dependencies
+        (["--update-packages"], True, True, f"=={NEW_VERSION}", True, None),
+    ],
+)
+def test_run_default_with_flags(
+    complex_temp_path,
+    complex_cleanup_dependencies_folder,
+    mox_path,
+    cli_args,
+    expect_gh_path,
+    expect_pip_path,
+    expect_pip_version,
+    expect_gh_package,
+    dependencies,
 ):
+    current_dir = Path.cwd()
+    if dependencies is not None:
+        old_moccasin_toml = rewrite_temp_moccasin_toml_dependencies(
+            complex_temp_path, dependencies
+        )
+    else:
+        old_moccasin_toml = rewrite_temp_moccasin_toml_dependencies(complex_temp_path)
+
+    try:
+        os.chdir(current_dir.joinpath(complex_temp_path))
+        base_args = [mox_path, "run", "deploy"]
+        result = subprocess.run(
+            base_args + cli_args, check=True, capture_output=True, text=True
+        )
+    finally:
+        os.chdir(current_dir)
+
+    assert complex_temp_path.joinpath(LIB_GH_PATH).exists() == expect_gh_path
+    assert complex_temp_path.joinpath(LIB_PIP_PATH).exists() == expect_pip_path
+
+    # Verify config state if versions are expected
+    project_root: Path = Config.find_project_root(complex_temp_path)
+    config = Config(project_root)
+    github_versions, pip_versions = get_temp_versions_toml_from_libs(complex_temp_path)
+    assert f"{PIP_PACKAGE_NAME}{expect_pip_version}" in config.dependencies
+    if expect_pip_path and expect_pip_version:
+        assert pip_versions[f"{PIP_PACKAGE_NAME}"] == expect_pip_version
+    if expect_gh_path and expect_gh_package:
+        assert PATRICK_PACKAGE_NAME in config.dependencies
+        assert github_versions[f"{PATRICK_PACKAGE_NAME}"] == "0.1.1"
+
+    assert "Ending count:  1" in result.stdout
+
+    # Reset toml to the original for next test
+    with open(complex_temp_path.joinpath(MOCCASIN_TOML), "wb") as f:
+        tomli_w.dump(old_moccasin_toml, f)
+
+
+def and_update(complex_temp_path, complex_cleanup_out_folder, mox_path):
     current_dir = Path.cwd()
     try:
         os.chdir(current_dir.joinpath(complex_temp_path))

--- a/tests/cli/test_cli_run.py
+++ b/tests/cli/test_cli_run.py
@@ -2,11 +2,23 @@ import os
 import subprocess
 from pathlib import Path
 
+import tomli_w
+
+from moccasin.config import Config
 from tests.constants import (
     ANVIL1_KEYSTORE_NAME,
     ANVIL1_KEYSTORE_PASSWORD,
     ANVIL1_PRIVATE_KEY,
+    LIB_GH_PATH,
     LIB_PIP_PATH,
+    MOCCASIN_TOML,
+    NEW_VERSION,
+    PATRICK_PACKAGE_NAME,
+    PIP_PACKAGE_NAME,
+)
+from tests.utils.helpers import (
+    get_temp_versions_toml_from_libs,
+    rewrite_temp_moccasin_toml_dependencies,
 )
 
 
@@ -37,6 +49,54 @@ def test_run_default(mox_path, complex_cleanup_dependencies_folder, complex_temp
 
     assert complex_temp_path.joinpath(LIB_PIP_PATH).exists()
     assert "Ending count:  1" in result.stdout
+
+
+def test_run_default_and_update(
+    complex_temp_path, complex_cleanup_out_folder, mox_path
+):
+    current_dir = Path.cwd()
+    try:
+        os.chdir(current_dir.joinpath(complex_temp_path))
+        result = subprocess.run(
+            [mox_path, "run", "deploy"], check=True, capture_output=True, text=True
+        )
+    finally:
+        os.chdir(current_dir)
+
+    assert complex_temp_path.joinpath(LIB_PIP_PATH).exists()
+    assert "Ending count:  1" in result.stdout
+
+    # Second run should update the version in the config
+    old_moccasin_toml = rewrite_temp_moccasin_toml_dependencies(complex_temp_path)
+
+    try:
+        os.chdir(current_dir.joinpath(complex_temp_path))
+        result_two = subprocess.run(
+            [mox_path, "run", "deploy", "--update-packages"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    finally:
+        os.chdir(current_dir)
+
+    assert complex_temp_path.joinpath(LIB_GH_PATH).exists()
+    assert complex_temp_path.joinpath(LIB_PIP_PATH).exists()
+
+    project_root: Path = Config.find_project_root(complex_temp_path)
+    config = Config(project_root)
+    assert f"{PIP_PACKAGE_NAME}=={NEW_VERSION}" in config.dependencies
+    assert f"{PATRICK_PACKAGE_NAME}" in config.dependencies
+
+    github_versions, pip_versions = get_temp_versions_toml_from_libs(complex_temp_path)
+    assert github_versions[f"{PATRICK_PACKAGE_NAME}"] == "0.1.1"
+    assert pip_versions[f"{PIP_PACKAGE_NAME}"] == f"=={NEW_VERSION}"
+
+    assert "Ending count:  1" in result_two.stdout
+
+    # Reset toml to the original for next test
+    with open(complex_temp_path.joinpath(MOCCASIN_TOML), "wb") as f:
+        tomli_w.dump(old_moccasin_toml, f)
 
 
 def test_multiple_manifest_returns_the_same_or_different(mox_path, complex_temp_path):

--- a/tests/cli/test_cli_test.py
+++ b/tests/cli/test_cli_test.py
@@ -2,6 +2,22 @@ import os
 import subprocess
 from pathlib import Path
 
+import tomli_w
+
+from moccasin.config import Config
+from tests.constants import (
+    LIB_GH_PATH,
+    LIB_PIP_PATH,
+    MOCCASIN_TOML,
+    NEW_VERSION,
+    PATRICK_PACKAGE_NAME,
+    PIP_PACKAGE_NAME,
+)
+from tests.utils.helpers import (
+    get_temp_versions_toml_from_libs,
+    rewrite_temp_moccasin_toml_dependencies,
+)
+
 EXPECTED_HELP_TEXT = "Runs pytest"
 
 
@@ -113,6 +129,61 @@ def test_staging_flag_live_networks(mox_path, complex_temp_path, anvil):
     # Check for the error message in the output
     assert "2 passed" in result.stdout
     assert "7 skipped" in result.stdout
+
+
+def test_staging_flag_live_networks_and_update(mox_path, complex_temp_path, anvil):
+    current_dir = Path.cwd()
+    try:
+        os.chdir(current_dir.joinpath(complex_temp_path))
+        result = subprocess.run(
+            [mox_path, "test", "--network", "anvil"], capture_output=True, text=True
+        )
+    finally:
+        os.chdir(current_dir)
+
+    assert result.returncode == 0
+
+    # Check for the error message in the output
+    assert "2 passed" in result.stdout
+    assert "7 skipped" in result.stdout
+
+    # Second run should update the version in the config
+    # @dev issue with import file mismatch if we import Patrick package
+    dependencies = [f"{PIP_PACKAGE_NAME}=={NEW_VERSION}"]
+    old_moccasin_toml = rewrite_temp_moccasin_toml_dependencies(
+        complex_temp_path, dependencies
+    )
+
+    try:
+        os.chdir(current_dir.joinpath(complex_temp_path))
+        result_two = subprocess.run(
+            [mox_path, "test", "--network", "anvil", "--update-packages"],
+            capture_output=True,
+            text=True,
+        )
+    finally:
+        os.chdir(current_dir)
+
+    assert not complex_temp_path.joinpath(LIB_GH_PATH).exists()
+    assert complex_temp_path.joinpath(LIB_PIP_PATH).exists()
+
+    project_root: Path = Config.find_project_root(complex_temp_path)
+    config = Config(project_root)
+    assert f"{PIP_PACKAGE_NAME}=={NEW_VERSION}" in config.dependencies
+    assert f"{PATRICK_PACKAGE_NAME}" not in config.dependencies
+
+    github_versions, pip_versions = get_temp_versions_toml_from_libs(complex_temp_path)
+    assert not bool(github_versions)
+    assert pip_versions[f"{PIP_PACKAGE_NAME}"] == f"=={NEW_VERSION}"
+
+    # Check for the error message in the output
+    assert result_two.returncode == 0
+    assert "2 passed" in result_two.stdout
+    assert "7 skipped" in result_two.stdout
+
+    # Reset toml to the original for next test
+    with open(complex_temp_path.joinpath(MOCCASIN_TOML), "wb") as f:
+        tomli_w.dump(old_moccasin_toml, f)
 
 
 def test_xdist_auto(mox_path, test_config_temp_path):

--- a/tests/cli/test_cli_test.py
+++ b/tests/cli/test_cli_test.py
@@ -2,6 +2,7 @@ import os
 import subprocess
 from pathlib import Path
 
+import pytest
 import tomli_w
 
 from moccasin.config import Config
@@ -12,6 +13,7 @@ from tests.constants import (
     NEW_VERSION,
     PATRICK_PACKAGE_NAME,
     PIP_PACKAGE_NAME,
+    VERSION,
 )
 from tests.utils.helpers import (
     get_temp_versions_toml_from_libs,
@@ -114,72 +116,90 @@ def test_test_gas(
     assert "coverage:" not in result.stdout
 
 
-def test_staging_flag_live_networks(mox_path, complex_temp_path, anvil):
+def test_staging_flag_live_networks(
+    mox_path, complex_temp_path, complex_cleanup_dependencies_folder, anvil
+):
     current_dir = Path.cwd()
     try:
         os.chdir(current_dir.joinpath(complex_temp_path))
         result = subprocess.run(
-            [mox_path, "test", "--network", "anvil"], capture_output=True, text=True
-        )
-    finally:
-        os.chdir(current_dir)
-
-    assert result.returncode == 0
-
-    # Check for the error message in the output
-    assert "2 passed" in result.stdout
-    assert "7 skipped" in result.stdout
-
-
-def test_staging_flag_live_networks_and_update(mox_path, complex_temp_path, anvil):
-    current_dir = Path.cwd()
-    try:
-        os.chdir(current_dir.joinpath(complex_temp_path))
-        result = subprocess.run(
-            [mox_path, "test", "--network", "anvil"], capture_output=True, text=True
-        )
-    finally:
-        os.chdir(current_dir)
-
-    assert result.returncode == 0
-
-    # Check for the error message in the output
-    assert "2 passed" in result.stdout
-    assert "7 skipped" in result.stdout
-
-    # Second run should update the version in the config
-    # @dev issue with import file mismatch if we import Patrick package
-    dependencies = [f"{PIP_PACKAGE_NAME}=={NEW_VERSION}"]
-    old_moccasin_toml = rewrite_temp_moccasin_toml_dependencies(
-        complex_temp_path, dependencies
-    )
-
-    try:
-        os.chdir(current_dir.joinpath(complex_temp_path))
-        result_two = subprocess.run(
-            [mox_path, "test", "--network", "anvil", "--update-packages"],
+            [mox_path, "test", "--network", "anvil", "--no-install"],
             capture_output=True,
             text=True,
         )
     finally:
         os.chdir(current_dir)
 
-    assert not complex_temp_path.joinpath(LIB_GH_PATH).exists()
-    assert complex_temp_path.joinpath(LIB_PIP_PATH).exists()
-
-    project_root: Path = Config.find_project_root(complex_temp_path)
-    config = Config(project_root)
-    assert f"{PIP_PACKAGE_NAME}=={NEW_VERSION}" in config.dependencies
-    assert f"{PATRICK_PACKAGE_NAME}" not in config.dependencies
-
-    github_versions, pip_versions = get_temp_versions_toml_from_libs(complex_temp_path)
-    assert not bool(github_versions)
-    assert pip_versions[f"{PIP_PACKAGE_NAME}"] == f"=={NEW_VERSION}"
+    assert result.returncode == 0
 
     # Check for the error message in the output
-    assert result_two.returncode == 0
-    assert "2 passed" in result_two.stdout
-    assert "7 skipped" in result_two.stdout
+    assert "2 passed" in result.stdout
+    assert "7 skipped" in result.stdout
+
+
+@pytest.mark.parametrize(
+    "cli_args, expect_gh_path, expect_pip_path, expect_pip_version, expect_gh_package, dependencies",
+    [
+        # --no-install should skip package installation
+        (["--no-install"], False, False, f"=={VERSION}", False, []),
+        # Default behavior - installs dependencies
+        ([], False, True, f"=={VERSION}", False, []),
+        # --update-packages should update existing dependencies
+        (
+            ["--update-packages"],
+            False,
+            True,
+            f"=={NEW_VERSION}",
+            True,
+            [f"{PIP_PACKAGE_NAME}=={NEW_VERSION}"],
+        ),
+    ],
+)
+def test_staging_flag_live_networks_with_flags(
+    complex_temp_path,
+    complex_cleanup_out_folder,
+    anvil,
+    mox_path,
+    cli_args,
+    expect_gh_path,
+    expect_pip_path,
+    expect_pip_version,
+    expect_gh_package,
+    dependencies,
+):
+    current_dir = Path.cwd()
+    if dependencies is not None:
+        old_moccasin_toml = rewrite_temp_moccasin_toml_dependencies(
+            complex_temp_path, dependencies
+        )
+    else:
+        old_moccasin_toml = rewrite_temp_moccasin_toml_dependencies(complex_temp_path)
+
+    try:
+        os.chdir(complex_temp_path)
+        base_args = [mox_path, "test", "--network", "anvil"]
+        result = subprocess.run(base_args + cli_args, capture_output=True, text=True)
+    finally:
+        os.chdir(current_dir)
+
+    assert complex_temp_path.joinpath(LIB_GH_PATH).exists() == expect_gh_path
+    assert complex_temp_path.joinpath(LIB_PIP_PATH).exists() == expect_pip_path
+
+    # Verify config state if versions are expected
+    project_root: Path = Config.find_project_root(complex_temp_path)
+    config = Config(project_root)
+    github_versions, pip_versions = get_temp_versions_toml_from_libs(complex_temp_path)
+    assert f"{PIP_PACKAGE_NAME}{expect_pip_version}" in config.dependencies
+    if expect_pip_path and expect_pip_version:
+        assert pip_versions[f"{PIP_PACKAGE_NAME}"] == expect_pip_version
+    if expect_gh_path and expect_gh_package:
+        assert PATRICK_PACKAGE_NAME in config.dependencies
+        assert github_versions[f"{PATRICK_PACKAGE_NAME}"] == "0.1.1"
+
+    # Check for the error message in the output
+    assert result.returncode == 0
+    assert "2 passed" in result.stdout
+    assert "7 skipped" in result.stdout
 
     # Reset toml to the original for next test
     with open(complex_temp_path.joinpath(MOCCASIN_TOML), "wb") as f:

--- a/tests/cli/test_cli_test.py
+++ b/tests/cli/test_cli_test.py
@@ -2,8 +2,6 @@ import os
 import subprocess
 from pathlib import Path
 
-from tests.constants import COMPLEX_PROJECT_PATH
-
 EXPECTED_HELP_TEXT = "Runs pytest"
 
 
@@ -11,9 +9,9 @@ def test_test_help(mox_path):
     result = subprocess.run(
         [mox_path, "test", "-h"], check=True, capture_output=True, text=True
     )
-    assert (
-        EXPECTED_HELP_TEXT in result.stdout
-    ), "Help output does not contain expected text"
+    assert EXPECTED_HELP_TEXT in result.stdout, (
+        "Help output does not contain expected text"
+    )
     assert result.returncode == 0
 
 
@@ -32,10 +30,12 @@ def test_basic(mox_path, complex_temp_path, anvil):
     assert "1 skipped" in result.stdout
 
 
-def test_test_complex_project_has_no_warnings(complex_cleanup_out_folder, mox_path):
+def test_test_complex_project_has_no_warnings(
+    complex_cleanup_out_folder, complex_temp_path, mox_path
+):
     current_dir = Path.cwd()
     try:
-        os.chdir(current_dir.joinpath(COMPLEX_PROJECT_PATH))
+        os.chdir(current_dir.joinpath(complex_temp_path))
         result = subprocess.run(
             [mox_path, "test"], check=True, capture_output=True, text=True
         )
@@ -45,10 +45,12 @@ def test_test_complex_project_has_no_warnings(complex_cleanup_out_folder, mox_pa
     assert result.returncode == 0
 
 
-def test_test_complex_project_passes_pytest_flags(complex_cleanup_out_folder, mox_path):
+def test_test_complex_project_passes_pytest_flags(
+    complex_cleanup_out_folder, complex_temp_path, mox_path
+):
     current_dir = Path.cwd()
     try:
-        os.chdir(current_dir.joinpath(COMPLEX_PROJECT_PATH))
+        os.chdir(current_dir.joinpath(complex_temp_path))
         result = subprocess.run(
             [mox_path, "test", "-k", "test_increment_two"],
             check=True,
@@ -62,10 +64,12 @@ def test_test_complex_project_passes_pytest_flags(complex_cleanup_out_folder, mo
     assert result.returncode == 0
 
 
-def test_test_coverage(complex_cleanup_out_folder, complex_cleanup_coverage, mox_path):
+def test_test_coverage(
+    complex_cleanup_out_folder, complex_cleanup_coverage, complex_temp_path, mox_path
+):
     current_dir = Path.cwd()
     try:
-        os.chdir(current_dir.joinpath(COMPLEX_PROJECT_PATH))
+        os.chdir(current_dir.joinpath(complex_temp_path))
         result = subprocess.run(
             [mox_path, "test", "--coverage"], check=True, capture_output=True, text=True
         )
@@ -73,13 +77,15 @@ def test_test_coverage(complex_cleanup_out_folder, complex_cleanup_coverage, mox
         os.chdir(current_dir)
     assert "coverage:" in result.stdout
     assert "Computation" not in result.stdout
-    assert current_dir.joinpath(COMPLEX_PROJECT_PATH).joinpath(".coverage").exists()
+    assert current_dir.joinpath(complex_temp_path).joinpath(".coverage").exists()
 
 
-def test_test_gas(complex_cleanup_out_folder, complex_cleanup_coverage, mox_path):
+def test_test_gas(
+    complex_cleanup_out_folder, complex_cleanup_coverage, complex_temp_path, mox_path
+):
     current_dir = Path.cwd()
     try:
-        os.chdir(current_dir.joinpath(COMPLEX_PROJECT_PATH))
+        os.chdir(current_dir.joinpath(complex_temp_path))
         result = subprocess.run(
             [mox_path, "test", "--gas-profile"],
             check=True,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,6 +20,8 @@ from tests.constants import (
     COMPLEX_PROJECT_PATH,
     INSTALL_PROJECT_PATH,
     INSTALLATION_STARTING_TOML,
+    INSTALLATION_WITH_GH_TOML,
+    INSTALLATION_WITH_PIP_TOML,
     NO_CONFIG_PROJECT_PATH,
     PURGE_PROJECT_PATH,
     PURGE_STARTING_TOML,
@@ -157,6 +159,26 @@ def installation_cleanup_dependencies(installation_temp_path):
     created_folder_path = installation_temp_path.joinpath(DEPENDENCIES_FOLDER)
     with open(installation_temp_path.joinpath("moccasin.toml"), "w") as f:
         f.write(INSTALLATION_STARTING_TOML)
+    if os.path.exists(created_folder_path):
+        shutil.rmtree(created_folder_path)
+
+
+@pytest.fixture
+def installation_cleanup_keep_pip_dependencies(installation_temp_path):
+    yield
+    created_folder_path = installation_temp_path.joinpath(DEPENDENCIES_FOLDER)
+    with open(installation_temp_path.joinpath("moccasin.toml"), "w") as f:
+        f.write(INSTALLATION_WITH_PIP_TOML)
+    if os.path.exists(created_folder_path):
+        shutil.rmtree(created_folder_path)
+
+
+@pytest.fixture
+def installation_cleanup_keep_gh_dependencies(installation_temp_path):
+    yield
+    created_folder_path = installation_temp_path.joinpath(DEPENDENCIES_FOLDER)
+    with open(installation_temp_path.joinpath("moccasin.toml"), "w") as f:
+        f.write(INSTALLATION_WITH_GH_TOML)
     if os.path.exists(created_folder_path):
         shutil.rmtree(created_folder_path)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,6 +19,8 @@ from tests.constants import (
     ANVIL_STORED_STATE_PATH,
     COMPLEX_PROJECT_PATH,
     INSTALL_PROJECT_PATH,
+    INSTALLATION_FULL_DEPENDENCIES_TOML,
+    INSTALLATION_NO_DEPENDENCIES_TOML,
     INSTALLATION_STARTING_TOML,
     INSTALLATION_WITH_GH_TOML,
     INSTALLATION_WITH_PIP_TOML,
@@ -164,23 +166,27 @@ def installation_cleanup_dependencies(installation_temp_path):
 
 
 @pytest.fixture
-def installation_cleanup_keep_pip_dependencies(installation_temp_path):
-    yield
-    created_folder_path = installation_temp_path.joinpath(DEPENDENCIES_FOLDER)
+def installation_remove_dependencies(installation_temp_path):
     with open(installation_temp_path.joinpath("moccasin.toml"), "w") as f:
-        f.write(INSTALLATION_WITH_PIP_TOML)
-    if os.path.exists(created_folder_path):
-        shutil.rmtree(created_folder_path)
+        f.write(INSTALLATION_NO_DEPENDENCIES_TOML)
 
 
 @pytest.fixture
-def installation_cleanup_keep_gh_dependencies(installation_temp_path):
-    yield
-    created_folder_path = installation_temp_path.joinpath(DEPENDENCIES_FOLDER)
+def installation_keep_pip_dependencies(installation_temp_path):
+    with open(installation_temp_path.joinpath("moccasin.toml"), "w") as f:
+        f.write(INSTALLATION_WITH_PIP_TOML)
+
+
+@pytest.fixture
+def installation_keep_gh_dependencies(installation_temp_path):
     with open(installation_temp_path.joinpath("moccasin.toml"), "w") as f:
         f.write(INSTALLATION_WITH_GH_TOML)
-    if os.path.exists(created_folder_path):
-        shutil.rmtree(created_folder_path)
+
+
+@pytest.fixture
+def installation_keep_full_dependencies(installation_temp_path):
+    with open(installation_temp_path.joinpath("moccasin.toml"), "w") as f:
+        f.write(INSTALLATION_FULL_DEPENDENCIES_TOML)
 
 
 # ------------------------------------------------------------------

--- a/tests/constants.py
+++ b/tests/constants.py
@@ -58,15 +58,17 @@ chain_id = 11155111
 # ------------------------------------------------------------------
 #                           TEST LIB
 # ------------------------------------------------------------------
+COMMENT_CONTENT = "PRESERVE COMMENTS"
+NEW_VERSION = "0.0.5"
+ORG_NAME = "pcaversaccio"
+PIP_PACKAGE_NAME = "snekmate"
+VERSION = "0.1.0"
+GITHUB_PACKAGE_NAME = f"{ORG_NAME}/{PIP_PACKAGE_NAME}"
 LIB_GH_PATH = "lib/github"
 LIB_PIP_PATH = "lib/pypi"
 MOCCASIN_LIB_NAME = "moccasin"
-PIP_PACKAGE_NAME = "snekmate"
-ORG_NAME = "pcaversaccio"
-GITHUB_PACKAGE_NAME = f"{ORG_NAME}/{PIP_PACKAGE_NAME}"
-VERSION = "0.1.0"
-NEW_VERSION = "0.0.5"
-COMMENT_CONTENT = "PRESERVE COMMENTS"
+MOCCASIN_TOML = "moccasin.toml"
 PATRICK_ORG_NAME = "patrickalphac"
 PATRICK_REPO_NAME = "test_repo"
 PATRICK_PACKAGE_NAME = f"{PATRICK_ORG_NAME}/{PATRICK_REPO_NAME}"
+VERSIONS_TOML = "versions.toml"

--- a/tests/constants.py
+++ b/tests/constants.py
@@ -29,7 +29,12 @@ ANVIL_STORED_KEYSTORE_PATH = Path(__file__).parent.joinpath(
 #                            TEST TOML
 # ------------------------------------------------------------------
 INSTALLATION_STARTING_TOML = """[project]
-dependencies = ["snekmate", "moccasin"]
+dependencies = [
+    "snekmate", 
+    "moccasin", 
+    "PatrickAlphaC/test_repo@0.1.1",
+    "pcaversaccio/snekmate",
+]
 
 # PRESERVE COMMENTS
 
@@ -51,8 +56,11 @@ chain_id = 11155111
 
 
 # ------------------------------------------------------------------
-#                           TEST GITHUB
+#                           TEST LIB
 # ------------------------------------------------------------------
+LIB_GH_PATH = "lib/github"
+LIB_PIP_PATH = "lib/pypi"
+MOCCASIN_LIB_NAME = "moccasin"
 PIP_PACKAGE_NAME = "snekmate"
 ORG_NAME = "pcaversaccio"
 GITHUB_PACKAGE_NAME = f"{ORG_NAME}/{PIP_PACKAGE_NAME}"

--- a/tests/constants.py
+++ b/tests/constants.py
@@ -44,6 +44,34 @@ chain_id = 11155111
 save_to_db = false
 """
 
+INSTALLATION_WITH_PIP_TOML = """[project]
+dependencies = [
+    "snekmate", 
+    "moccasin", 
+]
+
+# PRESERVE COMMENTS
+
+[networks.sepolia]
+url = "https://ethereum-sepolia-rpc.publicnode.com"
+chain_id = 11155111
+save_to_db = false
+"""
+
+INSTALLATION_WITH_GH_TOML = """[project]
+dependencies = [
+    "PatrickAlphaC/test_repo@0.1.1",
+    "pcaversaccio/snekmate",
+]
+
+# PRESERVE COMMENTS
+
+[networks.sepolia]
+url = "https://ethereum-sepolia-rpc.publicnode.com"
+chain_id = 11155111
+save_to_db = false
+"""
+
 PURGE_STARTING_TOML = """[project]
 dependencies = ["snekmate", "patrickalphac/test_repo"]
 

--- a/tests/constants.py
+++ b/tests/constants.py
@@ -110,6 +110,24 @@ chain_id = 11155111
 """
 
 
+COMPLEX_UPDATE_PACKAGES_TOML = """[project]
+dependencies = [
+    "snekmate==0.0.5", 
+    "PatrickAlphaC/test_repo",
+]
+src = "contracts"
+out = "build"
+save_abi_path = "abis"
+cov_config = ".coveragerc"
+dot_env = ".hello"
+db_path = ".deployments.db"
+
+# PRESERVE COMMENTS
+
+[networks.sepolia]
+url = "https://ethereum-sepolia-rpc.publicnode.com"
+chain_id = 11155111
+"""
 # ------------------------------------------------------------------
 #                           TEST LIB
 # ------------------------------------------------------------------

--- a/tests/constants.py
+++ b/tests/constants.py
@@ -32,8 +32,7 @@ INSTALLATION_STARTING_TOML = """[project]
 dependencies = [
     "snekmate", 
     "moccasin", 
-    "PatrickAlphaC/test_repo@0.1.1",
-    "pcaversaccio/snekmate",
+    "PatrickAlphaC/test_repo",
 ]
 
 # PRESERVE COMMENTS
@@ -43,6 +42,18 @@ url = "https://ethereum-sepolia-rpc.publicnode.com"
 chain_id = 11155111
 save_to_db = false
 """
+
+INSTALLATION_NO_DEPENDENCIES_TOML = """[project]
+dependencies = []
+
+# PRESERVE COMMENTS
+
+[networks.sepolia]
+url = "https://ethereum-sepolia-rpc.publicnode.com"
+chain_id = 11155111
+save_to_db = false
+"""
+
 
 INSTALLATION_WITH_PIP_TOML = """[project]
 dependencies = [
@@ -60,6 +71,22 @@ save_to_db = false
 
 INSTALLATION_WITH_GH_TOML = """[project]
 dependencies = [
+    "PatrickAlphaC/test_repo@0.1.1",
+    "pcaversaccio/snekmate",
+]
+
+# PRESERVE COMMENTS
+
+[networks.sepolia]
+url = "https://ethereum-sepolia-rpc.publicnode.com"
+chain_id = 11155111
+save_to_db = false
+"""
+
+INSTALLATION_FULL_DEPENDENCIES_TOML = """[project]
+dependencies = [
+    "snekmate", 
+    "moccasin",
     "PatrickAlphaC/test_repo@0.1.1",
     "pcaversaccio/snekmate",
 ]

--- a/tests/constants.py
+++ b/tests/constants.py
@@ -110,24 +110,6 @@ chain_id = 11155111
 """
 
 
-COMPLEX_UPDATE_PACKAGES_TOML = """[project]
-dependencies = [
-    "snekmate==0.0.5", 
-    "PatrickAlphaC/test_repo",
-]
-src = "contracts"
-out = "build"
-save_abi_path = "abis"
-cov_config = ".coveragerc"
-dot_env = ".hello"
-db_path = ".deployments.db"
-
-# PRESERVE COMMENTS
-
-[networks.sepolia]
-url = "https://ethereum-sepolia-rpc.publicnode.com"
-chain_id = 11155111
-"""
 # ------------------------------------------------------------------
 #                           TEST LIB
 # ------------------------------------------------------------------

--- a/tests/constants.py
+++ b/tests/constants.py
@@ -113,6 +113,7 @@ chain_id = 11155111
 # ------------------------------------------------------------------
 #                           TEST LIB
 # ------------------------------------------------------------------
+# @dev latest version can be problematic to follow, so tests might fail later on
 COMMENT_CONTENT = "PRESERVE COMMENTS"
 NEW_VERSION = "0.0.5"
 ORG_NAME = "pcaversaccio"
@@ -123,6 +124,7 @@ LIB_GH_PATH = "lib/github"
 LIB_PIP_PATH = "lib/pypi"
 MOCCASIN_LIB_NAME = "moccasin"
 MOCCASIN_TOML = "moccasin.toml"
+MOCCASIN_VERSION = "0.3.8"
 PATRICK_ORG_NAME = "patrickalphac"
 PATRICK_REPO_NAME = "test_repo"
 PATRICK_PACKAGE_NAME = f"{PATRICK_ORG_NAME}/{PATRICK_REPO_NAME}"

--- a/tests/data/complex_project/moccasin.toml
+++ b/tests/data/complex_project/moccasin.toml
@@ -87,3 +87,14 @@ usdc = { address = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48", abi_from_explor
 
 [networks.mainnet_fork.extra_data]
 usdc = "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
+
+[tool.moccasin.project]
+src = "src"
+dependencies = ["moccasin==0.3.0"]
+
+[tool.moccasin.networks.contracts.pyproject_contract]
+abi = "BuyMeACoffee"
+force_deploy = false
+
+[tool.moccasin.networks.silly_network]
+chain_id = 7777

--- a/tests/data/complex_project/moccasin.toml
+++ b/tests/data/complex_project/moccasin.toml
@@ -1,7 +1,5 @@
 [project]
-dependencies = [
-    "snekmate==0.1.0",
-]
+dependencies = ["snekmate==0.1.0"]
 src = "contracts"
 out = "build"
 save_abi_path = "abis"

--- a/tests/data/installation_project/moccasin.toml
+++ b/tests/data/installation_project/moccasin.toml
@@ -1,5 +1,10 @@
 [project]
-dependencies = ["patrickalphac/test_repo@0.1.1", "pcaversaccio/snekmate@0.1.0", "snekmate", "moccasin"]
+dependencies = [
+    "snekmate",
+    "moccasin",
+    "patrickalphac/test_repo@0.1.1",
+    "pcaversaccio/snekmate@0.1.0",
+]
 
 # PRESERVE COMMENTS
 

--- a/tests/data/installation_project/moccasin.toml
+++ b/tests/data/installation_project/moccasin.toml
@@ -1,10 +1,5 @@
 [project]
-dependencies = [
-    "snekmate",
-    "moccasin",
-    "patrickalphac/test_repo@0.1.1",
-    "pcaversaccio/snekmate@0.1.0",
-]
+dependencies = []
 
 # PRESERVE COMMENTS
 

--- a/tests/data/installation_project/moccasin.toml
+++ b/tests/data/installation_project/moccasin.toml
@@ -1,9 +1,5 @@
 [project]
-dependencies = [
-    "snekmate",
-    "moccasin",
-    "PatrickAlphaC/test_repo",
-]
+dependencies = ["patrickalphac/test_repo@0.1.1", "pcaversaccio/snekmate@0.1.0", "snekmate", "moccasin"]
 
 # PRESERVE COMMENTS
 

--- a/tests/data/installation_project/moccasin.toml
+++ b/tests/data/installation_project/moccasin.toml
@@ -1,5 +1,5 @@
 [project]
-dependencies = []
+dependencies = ["snekmate", "moccasin", "PatrickAlphaC/test_repo"]
 
 # PRESERVE COMMENTS
 

--- a/tests/integration/test_integration_explorer.py
+++ b/tests/integration/test_integration_explorer.py
@@ -52,7 +52,14 @@ def test_get_abi_from_script_etherscan(mox_path, complex_project_config):
     os.chdir(COMPLEX_PROJECT_PATH)
     try:
         result = subprocess.run(
-            [mox_path, "run", "get_usdc_balance", "--network", "mainnet_fork"],
+            [
+                mox_path,
+                "run",
+                "get_usdc_balance",
+                "--network",
+                "mainnet_fork",
+                "--no-install",
+            ],
             check=True,
             capture_output=True,
             text=True,

--- a/tests/integration/test_integration_install.py
+++ b/tests/integration/test_integration_install.py
@@ -125,7 +125,7 @@ def test_can_change_versions(
     current_dir = Path.cwd()
     try:
         os.chdir(installation_temp_path)
-        result_one = subprocess.run(
+        subprocess.run(
             [mox_path, "install", f"{GITHUB_PACKAGE_NAME}@{VERSION}"],
             check=True,
             capture_output=True,
@@ -139,8 +139,8 @@ def test_can_change_versions(
         )
     finally:
         os.chdir(current_dir)
-    assert f"Installed {GITHUB_PACKAGE_NAME}" in result_one.stderr
-    assert f"Updating {GITHUB_PACKAGE_NAME}" in result_two.stderr
+    assert f"{GITHUB_PACKAGE_NAME} needs to be updated from version {VERSION} to {NEW_VERSION}"
+    assert f"Updated {GITHUB_PACKAGE_NAME}" in result_two.stderr
     project_root: Path = Config.find_project_root(Path(installation_temp_path))
     config = Config(project_root)
     assert f"{GITHUB_PACKAGE_NAME}@{NEW_VERSION}" in config.dependencies

--- a/tests/integration/test_integration_install.py
+++ b/tests/integration/test_integration_install.py
@@ -80,7 +80,7 @@ def test_write_to_config_after_install(
         subprocess.run(
             [mox_path, "install", GITHUB_PACKAGE_NAME],
             check=True,
-            capture_output=True,
+            capture_output=False,
             text=True,
         )
     finally:
@@ -108,7 +108,7 @@ def test_can_install_with_version(
         )
     finally:
         os.chdir(current_dir)
-    assert f"Installed {GITHUB_PACKAGE_NAME}" in result.stderr
+    assert f"Installed new package: {GITHUB_PACKAGE_NAME}" in result.stderr
     project_root: Path = Config.find_project_root(Path(installation_temp_path))
     config = Config(project_root)
     assert f"{GITHUB_PACKAGE_NAME}@{VERSION}" in config.dependencies
@@ -139,8 +139,11 @@ def test_can_change_versions(
         )
     finally:
         os.chdir(current_dir)
-    assert f"{GITHUB_PACKAGE_NAME} needs to be updated from version {VERSION} to {NEW_VERSION}"
-    assert f"Updated {GITHUB_PACKAGE_NAME}" in result_two.stderr
+    assert (
+        f"{GITHUB_PACKAGE_NAME} needs to be updated from version {VERSION} to {NEW_VERSION}"
+        in result_two.stderr
+    )
+    assert f"Updated package: {GITHUB_PACKAGE_NAME}" in result_two.stderr
     project_root: Path = Config.find_project_root(Path(installation_temp_path))
     config = Config(project_root)
     assert f"{GITHUB_PACKAGE_NAME}@{NEW_VERSION}" in config.dependencies

--- a/tests/integration/test_integration_install.py
+++ b/tests/integration/test_integration_install.py
@@ -90,7 +90,7 @@ def test_write_to_config_after_install(
     config = Config(project_root)
     assert GITHUB_PACKAGE_NAME in config.dependencies
     for dep in starting_dependencies:
-        assert dep in config.dependencies
+        assert dep.lower() in config.dependencies
     assert COMMENT_CONTENT in config.read_configs_preserve_comments().as_string()
 
 

--- a/tests/live/test_live_verify.py
+++ b/tests/live/test_live_verify.py
@@ -21,6 +21,7 @@ def test_zksync_verify(mox_path):
                 "sepolia-zksync",
                 "--account",
                 "smalltestnet",
+                "--no-install",
             ],
             check=True,
             capture_output=True,

--- a/tests/utils/helpers.py
+++ b/tests/utils/helpers.py
@@ -1,0 +1,74 @@
+import tomllib
+from pathlib import Path
+
+import tomli_w
+
+from tests.constants import (
+    LIB_GH_PATH,
+    LIB_PIP_PATH,
+    MOCCASIN_TOML,
+    NEW_VERSION,
+    PATRICK_PACKAGE_NAME,
+    PIP_PACKAGE_NAME,
+    VERSIONS_TOML,
+)
+
+
+def rewrite_temp_moccasin_toml_dependencies(
+    temp_path: Path,
+    dependencies: list[str] = [
+        f"{PIP_PACKAGE_NAME}=={NEW_VERSION}",
+        f"{PATRICK_PACKAGE_NAME}",
+    ],
+) -> dict:
+    """Rewrite the moccasin.toml file with new dependencies
+
+    :param temp_path: Path to the temporary directory containing the moccasin.toml file.
+    :type temp_path: Path
+    :param dependencies: List of dependencies to add to the moccasin.toml file.
+    :type dependencies: list[str]
+    :return: Configuration data from the moccasin.toml file.
+    :rtype: dict
+    """
+    if not temp_path.joinpath(MOCCASIN_TOML).exists():
+        return {}
+
+    # Read the moccasin.toml file
+    with open(temp_path.joinpath(MOCCASIN_TOML), "rb") as f:
+        old_moccasin_toml = tomllib.load(f)
+    with open(temp_path.joinpath(MOCCASIN_TOML), "wb") as f:
+        # Update dependencies of moccasin.toml
+        # @dev add new dependencies and keep config
+        new_moccasin_toml = {
+            **old_moccasin_toml,
+            "project": {**old_moccasin_toml["project"], "dependencies": dependencies},
+        }
+        tomli_w.dump(new_moccasin_toml, f)
+
+    return old_moccasin_toml
+
+
+def get_temp_versions_toml_from_libs(temp_path: Path) -> tuple[dict, dict]:
+    """Get the versions (github and pip) from their lib/github and lib/pypi toml files
+
+    :param temp_path: Path to the temporary directory containing the moccasin.toml file.
+    :type temp_path: Path
+    :return: A tuple containing two dictionaries, each containing the versions of the libraries.
+    :rtype: tuple[dict, dict]
+    """
+    github_versions = {}
+    pip_versions = {}
+
+    # Github versions
+    if temp_path.joinpath(LIB_GH_PATH).exists():
+        with open(temp_path.joinpath(LIB_GH_PATH).joinpath(VERSIONS_TOML), "rb") as f:
+            versions = tomllib.load(f)
+            github_versions = {k.lower(): v for k, v in versions.items()}
+
+    # Pip versions
+    if temp_path.joinpath(LIB_PIP_PATH).exists():
+        with open(temp_path.joinpath(LIB_PIP_PATH).joinpath(VERSIONS_TOML), "rb") as f:
+            versions = tomllib.load(f)
+            pip_versions = {k.lower(): v for k, v in versions.items()}
+
+    return github_versions, pip_versions

--- a/tests/utils/helpers.py
+++ b/tests/utils/helpers.py
@@ -36,6 +36,11 @@ def rewrite_temp_moccasin_toml_dependencies(
     # Read the moccasin.toml file
     with open(temp_path.joinpath(MOCCASIN_TOML), "rb") as f:
         old_moccasin_toml = tomllib.load(f)
+
+    # Return if no dependencies are provided to keep the config
+    if len(dependencies) == 0:
+        return old_moccasin_toml
+
     with open(temp_path.joinpath(MOCCASIN_TOML), "wb") as f:
         # Update dependencies of moccasin.toml
         # @dev add new dependencies and keep config


### PR DESCRIPTION
Related issue: #174 

This is my solution for the issue/feature. It is open to any feedback, to improve in my journey since I have done it with my current experience level. It might not be suited to the original demand, so I am not against closing this PR or improve it if needed!

Thanks for your time!

`just test-all` -> OK
live test -> OK

⚠️ Need to update the doc

---

# Main Features Implemented: Automatic Dependency Management

- Integrated automatic dependency installation when running `build` and `deploy` commands
- System automatically checks and installs missing dependencies
- Handles both PyPI packages and GitHub repositories


# Key Components
## Installation System (mox_install)
- Central function for handling all installations
- Used by build, deploy as requested
- Supports both explicit installation requests and auto-installation

## Dependency Utilities (_dependency_utils.py)
- Smart dependency classification
- Version tracking and management -> `versions.toml` inside each lib folders with Pypi SpecifierSet format
- Handles both PyPI and GitHub package formats

## Package Managers
- PyPI: Uses uv package manager for Python packages -> added preprocessing with dep utilities (inspired from gihub implementation)
- GitHub: Custom implementation for GitHub repository downloads -> reworked but kept Brownie logic.


# Improvements proposed

## Code Organization
- Separated dependency utilities into a dedicated module
- Clear separation between PyPI and GitHub package handling
- Improved code documentation with Sphinx-style docstrings

## Test cases
- unit with install
- integrations
- zksync and live

## Configuration Management
- Version tracking in versions.toml


# Potential next features/refacto

- Auto-delete libs that are not in the `config.dependencies` anymore (removed from `moccasin.toml`)?
- Improve test cases -> I think there is room to add better test case from what I did and also optimize them
- Better code optimization from my PR -> maybe with more experienced Py dev to judge and improve my work
- Possible edge-case where a user can add `[package==0.0.5, package==0.1.0]` when `package==0.1.2` is already installed and triggers the uv pip error (yes the user has to intentionally add this error). But the fact is, maybe add a better filtering at first when we add `conf_dependencies + requirements`?  
