### PR TITLE
docs: NamedContract and MoccasinAccount class ref for #86

### DIFF
--- a/docs/source/api_reference/moccasin_account_reference.rst
+++ b/docs/source/api_reference/moccasin_account_reference.rst
@@ -4,4 +4,5 @@
 .. autoclass:: moccasin.moccasin_account.MoccasinAccount
    :members:
    :undoc-members:
+   :member-order: bysource
    :show-inheritance:

--- a/docs/source/api_reference/named_contract_reference.rst
+++ b/docs/source/api_reference/named_contract_reference.rst
@@ -4,4 +4,5 @@
 .. autoclass:: moccasin.named_contract.NamedContract
    :members:
    :undoc-members:
+   :member-order: bysource
    :show-inheritance:

--- a/moccasin/config.py
+++ b/moccasin/config.py
@@ -79,44 +79,44 @@ class Network:
     This class allows for flexible network configuration across different blockchain environments,
     supporting both local and remote networks, including special cases like forked networks.
 
-    :ivar name: Unique identifier for the network
-    :vartype name: str
-    :ivar url: Network endpoint URL
-    :vartype url: str | None
-    :ivar chain_id: Unique identifier for the blockchain network
-    :vartype chain_id: int | None
-    :ivar is_fork: Indicates if the network is a forked instance
-    :vartype is_fork: bool
-    :ivar block_identifier: Block identifier for the network
-    :vartype block_identifier: int | str
-    :ivar is_zksync: Indicates if the network is a zkSync network
-    :vartype is_zksync: bool
-    :ivar default_account_name: Default mox wallet account name to use for the network
-    :vartype default_account_name: str | None
-    :ivar unsafe_password_file: Path to the unsafe password file related to ``default_account_name``
-    :vartype unsafe_password_file: Path | None
-    :ivar save_abi_path: Path to save the ABI
-    :vartype save_abi_path: str | None
-    :ivar explorer_uri: URI of the explorer
-    :vartype explorer_uri: str | None
-    :ivar explorer_api_key: API key for the explorer
-    :vartype explorer_api_key: str | None
-    :ivar explorer_type: Type of the explorer ("blockscout", "etherscan", "zksyncexplorer")
-    :vartype explorer_type: str | None
-    :ivar named_contracts: Dictionary of named contracts
-    :vartype named_contracts: dict[str, NamedContract]
-    :ivar prompt_live: A flag that will prompt you before sending a transaction, it defaults to true for "non-testing" networks
-    :vartype prompt_live: bool
-    :ivar save_to_db: Indicates if the network should save the deployment to the database, it defaults to true for "non-testing" networks
-    :vartype save_to_db: bool
-    :ivar live_or_staging: Indicates if the network is live or staging, defaults to true for non-local, non-forked networks
-    :vartype live_or_staging: bool
-    :ivar db_path: Path to the database
-    :vartype db_path: str | Path
-    :ivar extra_data: Extra data for the network
-    :vartype extra_data: dict[str, Any]
-    :ivar _network_env: Network environment
-    :vartype _network_env: _AnyEnv | None
+    :param name: Unique identifier for the network
+    :type name: str
+    :param url: Network endpoint URL
+    :type url: str | None
+    :param chain_id: Unique identifier for the blockchain network
+    :type chain_id: int | None
+    :param is_fork: Indicates if the network is a forked instance
+    :type is_fork: bool
+    :param block_identifier: Block identifier for the network
+    :type block_identifier: int | str
+    :param is_zksync: Indicates if the network is a zkSync network
+    :type is_zksync: bool
+    :param default_account_name: Default mox wallet account name to use for the network
+    :type default_account_name: str | None
+    :param unsafe_password_file: Path to the unsafe password file related to ``default_account_name``
+    :type unsafe_password_file: Path | None
+    :param save_abi_path: Path to save the ABI
+    :type save_abi_path: str | None
+    :param explorer_uri: URI of the explorer
+    :type explorer_uri: str | None
+    :param explorer_api_key: API key for the explorer
+    :type explorer_api_key: str | None
+    :param explorer_type: Type of the explorer ("blockscout", "etherscan", "zksyncexplorer")
+    :type explorer_type: str | None
+    :param named_contracts: Dictionary of named contracts
+    :type named_contracts: dict[str, NamedContract]
+    :param prompt_live: A flag that will prompt you before sending a transaction, it defaults to true for "non-testing" networks
+    :type prompt_live: bool
+    :param save_to_db: Indicates if the network should save the deployment to the database, it defaults to true for "non-testing" networks
+    :type save_to_db: bool
+    :param live_or_staging: Indicates if the network is live or staging, defaults to true for non-local, non-forked networks
+    :type live_or_staging: bool
+    :param db_path: Path to the database
+    :type db_path: str | Path
+    :param extra_data: Extra data for the network
+    :type extra_data: dict[str, Any]
+    :param _network_env: Network environment
+    :type _network_env: _AnyEnv | None
     """
 
     name: str
@@ -1128,6 +1128,11 @@ class _Networks:
     handling both default network settings and network-specific overrides. It manages
     contract deployments, network connections, and explorer configurations for each network.
 
+    :param toml_data: The configuration data from the ``moccasin.toml`` file
+    :type toml_data: dict
+    :param project_root: The root directory of the project
+    :type project_root: Path
+
     :ivar _networks: Dictionary mapping network names to their Network objects
     :vartype _networks: dict[str, Network]
     :ivar _default_named_contracts: Default contract configurations that apply across all networks
@@ -1147,13 +1152,7 @@ class _Networks:
     default_network_name: str
 
     def __init__(self, toml_data: dict, project_root: Path):
-        """Initialize the _Networks class.
-
-        :param toml_data: The configuration data from the ``moccasin.toml`` file
-        :type toml_data: dict
-        :param project_root: The root directory of the project
-        :type project_root: Path
-        """
+        """Initialize the _Networks class."""
         self._networks = {}
         self._default_named_contracts = {}
         self._overriden_active_network = None
@@ -1536,6 +1535,9 @@ class Config:
 
     This class reads the `moccasin.toml` file and sets up project configuration.
 
+    :param root_path: The root directory of the project. Defaults to None.
+    :type root_path: Path, optional
+
     :ivar _project_root: The root directory of the project.
     :vartype _project_root: Path
     :ivar _toml_data: The parsed TOML data from the `moccasin.toml` file.
@@ -1558,11 +1560,7 @@ class Config:
     networks: _Networks
 
     def __init__(self, root_path: Path | None):
-        """Initialize the Config object.
-
-        :param root_path: The root directory of the project. Defaults to None.
-        :type root_path: Path, optional
-        """
+        """Initialize the Config object."""
         if root_path is None:
             root_path = Config.find_project_root()
         root_path = cast(Path, root_path)

--- a/moccasin/moccasin_account.py
+++ b/moccasin/moccasin_account.py
@@ -16,6 +16,34 @@ from moccasin.logging import logger
 
 
 class MoccasinAccount(LocalAccount):
+    """A class representing a Moccasin account, extending LocalAccount functionality.
+
+    This class provides enhanced account management features including keystore handling,
+    private key management, and account unlocking capabilities.
+
+    :param private_key: The private key for the account
+    :type private_key: str | bytes | None
+    :param keystore_path_or_account_name: Path to keystore file or account name
+    :type keystore_path_or_account_name: Path | str | None
+    :param password: Password for keystore decryption
+    :type password: str
+    :param password_file_path: Path to file containing password
+    :type password_file_path: Path
+    :param address: Address for the account
+    :type address: Address | None
+    :param ignore_warning: Whether to ignore warning about unlocked account
+    :type ignore_warning: bool
+
+    :ivar _private_key: The account's private key
+    :type _private_key: bytes | None
+    :ivar _address: The account's address
+    :type _address: ChecksumAddress | None
+    :ivar _publicapi: Public API instance for account operations
+    :type _publicapi: Account
+    :ivar keystore_path: Path to the account's keystore file
+    :type keystore_path: Path
+    """
+
     def __init__(
         self,
         private_key: str | bytes | None = None,
@@ -25,6 +53,7 @@ class MoccasinAccount(LocalAccount):
         address: Address | None = None,
         ignore_warning: bool = False,
     ):
+        """Initialize the MoccasinAccount object."""
         # We override the LocalAccount Type
         self._private_key: bytes | None = None  # type: ignore
         # We override the LocalAccount Type
@@ -57,10 +86,20 @@ class MoccasinAccount(LocalAccount):
 
     @property
     def private_key(self) -> bytes:
+        """Get the private key of the account.
+
+        :return: The private key in bytes
+        :rtype: bytes
+        """
         return self.key
 
     @property
     def address(self) -> ChecksumAddress | None:  # type: ignore
+        """Get the account's address.
+
+        :return: The account's checksum address or None if not set
+        :rtype: ChecksumAddress | None
+        """
         if self.private_key:
             return PrivateKey(self.private_key).public_key.to_checksum_address()
         if self._address:
@@ -68,6 +107,11 @@ class MoccasinAccount(LocalAccount):
         return None
 
     def _init_key(self, private_key: bytes | HexBytes):
+        """Initialize the account with a private key.
+
+        :param private_key: The private key to initialize with
+        :type private_key: bytes | HexBytes
+        """
         if isinstance(private_key, HexBytes):
             private_key = bytes(private_key)
         private_key_converted = PrivateKey(private_key)
@@ -77,11 +121,21 @@ class MoccasinAccount(LocalAccount):
         self._key_obj: PrivateKey = private_key_converted
 
     def set_keystore_path(self, keystore_path: Path | str):
+        """Set the path to the keystore file.
+
+        :param keystore_path: Path to the keystore file
+        :type keystore_path: Path | str
+        """
         if isinstance(keystore_path, str):
             keystore_path = MOCCASIN_KEYSTORE_PATH.joinpath(Path(keystore_path))
         self.keystore_path = keystore_path
 
     def unlocked(self) -> bool:
+        """Check if the account is unlocked.
+
+        :return: True if the account is unlocked, False otherwise
+        :rtype: bool
+        """
         return self.private_key is not None
 
     def unlock(
@@ -90,6 +144,18 @@ class MoccasinAccount(LocalAccount):
         password_file_path: Path = None,
         prompt_even_if_unlocked: bool = False,
     ) -> HexBytes:
+        """Unlock the account using a password or password file.
+
+        :param password: Password for keystore decryption
+        :type password: str
+        :param password_file_path: Path to file containing password
+        :type password_file_path: Path
+        :param prompt_even_if_unlocked: Whether to prompt for password even if account is already unlocked
+        :type prompt_even_if_unlocked: bool
+        :return: The decrypted private key
+        :rtype: HexBytes
+        :raises Exception: If no keystore path is provided
+        """
         if password_file_path:
             password_file_path = Path(password_file_path).expanduser().resolve()
         if not self.unlocked() or prompt_even_if_unlocked:
@@ -107,6 +173,11 @@ class MoccasinAccount(LocalAccount):
         return cast(HexBytes, self.private_key)
 
     def get_balance(self) -> int:
+        """Get the account balance using boa environment.
+
+        :return: The account balance in wei
+        :rtype: int
+        """
         # This might be dumb? Idk
         import boa
 
@@ -114,4 +185,11 @@ class MoccasinAccount(LocalAccount):
 
     @classmethod
     def from_boa_address(cls, address: Address) -> "MoccasinAccount":
+        """Create a MoccasinAccount instance from a boa address.
+
+        :param address: The boa address
+        :type address: Address
+        :return: A new MoccasinAccount instance
+        :rtype: MoccasinAccount
+        """
         return cls()

--- a/moccasin/named_contract.py
+++ b/moccasin/named_contract.py
@@ -11,8 +11,26 @@ from moccasin.logging import logger
 
 @dataclass
 class NamedContract:
-    """
-    A class to represent a named contract. These hold only data about NamedContracts from the config.
+    """A class to represent a named contract.
+
+    This class holds data about NamedContracts from the configuration and manages their deployment.
+
+    :param contract_name: The name of the contract
+    :type contract_name: str
+    :param force_deploy: Whether to force deployment of the contract
+    :type force_deploy: bool | None
+    :param abi: The ABI of the contract
+    :type abi: str | None
+    :param abi_from_explorer: Whether to fetch the ABI from the explorer
+    :type abi_from_explorer: bool | None
+    :param deployer_script: The path to the deployer script
+    :type deployer_script: str | Path | None
+    :param address: The address of the contract
+    :type address: str | None
+    :param deployer: The deployer instance for the contract
+    :type deployer: VyperDeployer | ZksyncDeployer | None
+    :param recently_deployed_contract: The recently deployed contract instance
+    :type recently_deployed_contract: VyperContract | ZksyncContract | None
     """
 
     # From the config
@@ -28,6 +46,11 @@ class NamedContract:
     recently_deployed_contract: VyperContract | ZksyncContract | None = None
 
     def set_defaults(self, other: "NamedContract"):
+        """Set default values from another NamedContract instance if they are not already set.
+
+        :param other: Another NamedContract instance to copy defaults from
+        :type other: NamedContract
+        """
         self.force_deploy = (
             self.force_deploy if self.force_deploy is not None else other.force_deploy
         )
@@ -45,17 +68,36 @@ class NamedContract:
         self.address = self.address if self.address is not None else other.address
 
     def reset(self):
+        """Reset the deployer and recently deployed contract to None."""
         self.deployer = None
         self.recently_deployed_contract = None
 
     def get(self, key: str, otherwise: Any):
+        """Get a NamedContract attribute value or return a default if the attribute is not set.
+
+        :param key: The attribute name to get
+        :type key: str
+        :param otherwise: The default value to return if the attribute is not set
+        :type otherwise: Any
+        :return: The attribute value or the default value
+        :rtype: Any
+        """
         return getattr(self, key, otherwise)
 
     def _deploy(
         self, script_folder: str, deployer_script: str | Path | None = None
     ) -> VyperContract | ZksyncContract:
-        """
+        """Deploy the contract using the specified deployer script.
+
         This function will not save the named contract to the database with it's name!
+
+        :param script_folder: The folder containing the deployer scripts
+        :type script_folder: str
+        :param deployer_script: The path to the deployer script, defaults to None
+        :type deployer_script: str | Path | None
+        :return: The deployed contract instance
+        :rtype: VyperContract | ZksyncContract
+        :raises ValueError: If deployer path is not provided or invalid contract type is returned
         """
         if deployer_script:
             deployer_script = str(deployer_script)


### PR DESCRIPTION
Related Issue: #86 

---

- Docstring added for ``NamedContract`` and ``MoccasinAccount``
- Refactor docstring ``param`` and ``ivar`` for clarity
- Moved docstring params from ``__init__`` to class docstring to show in official doc

I adapted `param` and `ivar` because I understood that `@dataclass` make the `__init__` automatically from the variables declared in the class. So they are not variables used during runtime but actual `params` to init the class.