### PR TITLE
fix: prevent merging specific pyproject keys in mox toml for #213

### DIFF
--- a/moccasin/config.py
+++ b/moccasin/config.py
@@ -2061,7 +2061,20 @@ class Config:
             )
 
         def deep_update(d, u):
+            # Special keys that should not be merged
+            pyproject_special_keys = [
+                "tool",
+                "build-systemname",
+                "name",
+                "version",
+                "description",
+                "readme",
+                "requires-python",
+            ]
+
             for k, v in u.items():
+                if k in pyproject_special_keys:
+                    continue
                 if isinstance(v, dict):
                     if k not in d:
                         d[k] = {}

--- a/moccasin/config.py
+++ b/moccasin/config.py
@@ -1646,7 +1646,14 @@ class Config:
         )
         if moccasin_config == {}:
             return pyproject_config
-        merged_config = self.merge_configs(moccasin_config, pyproject_config)
+
+        # Get moccasin specific config from pyproject
+        pyproject_mox_config = pyproject_config.get("tool", {}).get("moccasin", {})
+        if pyproject_mox_config == {}:
+            return moccasin_config
+
+        # Merge the two configs
+        merged_config = self.merge_configs(moccasin_config, pyproject_mox_config)
         merged_config = cast(tomlkit.TOMLDocument, merged_config)
         return merged_config
 
@@ -2034,7 +2041,7 @@ class Config:
     @staticmethod
     def merge_configs(
         moccasin_config_dict: Union[dict, tomlkit.TOMLDocument],
-        pyproject_config_dict: Union[dict, tomlkit.TOMLDocument],
+        pyproject_mox_config_dict: Union[dict, tomlkit.TOMLDocument],
     ) -> Union[dict, tomlkit.TOMLDocument]:
         """Merges the `moccasin` and `pyproject` configuration dictionaries.
 
@@ -2042,18 +2049,15 @@ class Config:
 
         :param moccasin_config_dict: Configuration from `moccasin.toml`.
         :type moccasin_config_dict: Union[dict, tomlkit.TOMLDocument]
-        :param pyproject_config_dict: Configuration from `pyproject.toml`.
-        :type pyproject_config_dict: Union[dict, tomlkit.TOMLDocument]
+        :param pyproject_mox_config_dict: Moccasin configuration from `pyproject.toml`.
+        :type pyproject_mox_config_dict: Union[dict, tomlkit.TOMLDocument]
         :return: The merged configuration dictionary.
         :rtype: Union[dict, tomlkit.TOMLDocument]
         """
         merged = moccasin_config_dict.copy()
 
         if (
-            pyproject_config_dict.get("tool", {})
-            .get("moccasin", {})
-            .get("project", {})
-            .get("dependencies", None)
+            pyproject_mox_config_dict.get("project", {}).get("dependencies", None)
             is not None
         ):
             logger.warning(
@@ -2061,20 +2065,7 @@ class Config:
             )
 
         def deep_update(d, u):
-            # Special keys that should not be merged
-            pyproject_special_keys = [
-                "tool",
-                "build-systemname",
-                "name",
-                "version",
-                "description",
-                "readme",
-                "requires-python",
-            ]
-
             for k, v in u.items():
-                if k in pyproject_special_keys:
-                    continue
                 if isinstance(v, dict):
                     if k not in d:
                         d[k] = {}
@@ -2083,7 +2074,7 @@ class Config:
                     d[k] = v
             return d
 
-        return deep_update(merged, pyproject_config_dict)
+        return deep_update(merged, pyproject_mox_config_dict)
 
     @staticmethod
     def _validated_pyproject_config_path(config_path: Path):

--- a/tests/integration/test_integration_compile.py
+++ b/tests/integration/test_integration_compile.py
@@ -28,7 +28,7 @@ EXPECTED_HELP_TEXT = "Vyper compiler"
     "cli_args, rewrite_dependencies, expected_lib_path, expected_pip_deps, expected_gh_deps, expected_gh_versions",
     [
         # --no-install should skip package installation
-        (["BuyMeACoffee.vy", "--no-install"], [], False, ["snekmate==0.1.0"], [], None),
+        (["BuyMeACoffee.vy", "--no-install"], [], False, [], [], None),
         # Default behavior - installs dependencies
         (
             ["BuyMeACoffee.vy"],
@@ -91,7 +91,8 @@ def test_compile_with_flags(
     # Verify config state if versions are expected
     project_root: Path = Config.find_project_root(complex_temp_path)
     config = Config(project_root)
-    assert config.dependencies == expected_pip_deps + expected_gh_deps
+    if "--no-install" not in cli_args:
+        assert config.dependencies == expected_pip_deps + expected_gh_deps
 
     # Verify gh versions file contents
     if expected_gh_versions:

--- a/tests/integration/test_integration_deploy.py
+++ b/tests/integration/test_integration_deploy.py
@@ -26,7 +26,7 @@ from tests.utils.helpers import (
     "cli_args, rewrite_dependencies, expected_lib_path, expected_pip_deps, expected_gh_deps, expected_gh_versions",
     [
         # --no-install should skip package installation
-        (["price_feed", "--no-install"], [], False, ["snekmate==0.1.0"], [], None),
+        (["price_feed", "--no-install"], [], False, [], [], None),
         # Default behavior - installs dependencies
         (
             ["price_feed"],
@@ -89,7 +89,8 @@ def test_deploy_price_feed_pyevm_with_flags(
     # Verify config state if versions are expected
     project_root: Path = Config.find_project_root(complex_temp_path)
     config = Config(project_root)
-    assert config.dependencies == expected_pip_deps + expected_gh_deps
+    if "--no-install" not in cli_args:
+        assert config.dependencies == expected_pip_deps + expected_gh_deps
 
     # Verify gh versions file contents
     if expected_gh_versions:


### PR DESCRIPTION
Quick fix to avoid merging pyproject keys in mox toml.

Can be improved with other clever methods.

Keys to avoid taken from https://packaging.python.org/en/latest/guides/writing-pyproject-toml/

---

Issue: #213