### PR TITLE
feat: improve devcontainer setup environment for #224

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,7 +9,9 @@
             "extensions": [
                 "tintinweb.vscode-vyper",
                 "trailofbits.weaudit",
-                "ms-python.python"
+                "ms-python.python",
+                "charliermarsh.ruff",
+                "tamasfe.even-better-toml"
             ],
             "settings": {
                 "terminal.integrated.defaultProfile.linux": "zsh",
@@ -17,7 +19,9 @@
                     "zsh": {
                         "path": "/usr/bin/zsh"
                     }
-                }
+                },
+                "python.terminal.activateEnvironment": true,
+                "python.defaultInterpreterPath": ".venv/bin/python"
             }
         }
     },

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,6 +6,5 @@
     "files.exclude": {
         "**/__pycache__": true
     },
-    "python.terminal.activateEnvironment": false,
     "python.terminal.executeInFileDir": true
 }


### PR DESCRIPTION
- avoid ``"python.terminal.activateEnvironment": false,`` in ``.vscode/settings.json`` -> it should not activate locally if not checked in personal settings
- add ``"python.terminal.activateEnvironment": true,`` in ``devcontainer.json`` -> now venv is activated in devcontainer terminal everytime
- add ruff and better toml support in devcontainer for better vscode experience

Issue: #224 