### PR TITLE
fix: apply zsh shell in postCreateCommand for #223

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -23,5 +23,5 @@
     },
     "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind,consistency=cached",
     "workspaceFolder": "/workspace",
-    "postCreateCommand": "uv venv && source .venv/bin/activate && uv sync --all-extras"
+    "postCreateCommand": "zsh -c 'uv venv && source .venv/bin/activate && uv sync --all-extras'"
 }


### PR DESCRIPTION
- fix ``/bin/sh: 1: source: not found`` error in devcontainer terminal by forcing zsh shell for ``source .venv/bin/activate``