### PR TITLE
Add support for Etherscan verification

### DIFF
--- a/docs/source/how-tos/verify_contracts.rst
+++ b/docs/source/how-tos/verify_contracts.rst
@@ -15,10 +15,11 @@ In your ``moccasin.toml`` add your explorer details:
     explorer_type = "zksyncexplorer"
     explorer_api_key = "None"
 
-Some networks, like ``sepolia-zksync``, have some of these details defaulted for you. You can check out the :doc:`/explorer_network_defaults` page to see what's available. As of today, the only supported explorers are:
+Some networks, like ``sepolia-zksync``, have some of these details defaulted for you. You can check out the :doc:`/explorer_network_defaults` page to see what's available. As of today, the supported explorers are:
 
 - `Blockscount explorer <https://www.blockscout.com/>`_
 - `ZKsync explorer <https://explorer.zksync.io/>`_
+- `Etherscan explorer <https://etherscan.io>`_
 
 
 2. Add ``moccasin_verify`` to your script

--- a/moccasin/config.py
+++ b/moccasin/config.py
@@ -31,6 +31,7 @@ from dotenv import load_dotenv
 from eth_utils import to_hex
 from tomlkit.items import Table
 
+from moccasin.constants.chains import ETHERSCAN_EXPLORERS
 from moccasin.constants.vars import (
     BUILD_FOLDER,
     CONFIG_NAME,
@@ -247,6 +248,8 @@ class Network:
                     self.explorer_type = "blockscout"
                 elif "zksync" in self.explorer_uri:
                     self.explorer_type = "zksyncexplorer"
+                elif self.explorer_uri.strip('/') in ETHERSCAN_EXPLORERS.keys():
+                    self.explorer_type = "etherscan"
 
         if self.explorer_type is None:
             raise ValueError(
@@ -275,8 +278,10 @@ class Network:
             return "Blockscout"
         if verifier_string.lower().strip() == "zksyncexplorer":
             return "ZksyncExplorer"
+        if verifier_string.lower().strip() == "etherscan":
+            return "Etherscan"
         raise ValueError(
-            f"Verifier {verifier_string} is not supported. Please use 'blockscout' or 'zksyncexplorer'."
+            f"Verifier {verifier_string} is not supported. Please use 'blockscout', 'etherscan' or 'zksyncexplorer'."
         )
 
     def get_default_account(self) -> MoccasinAccount | Any:

--- a/moccasin/constants/chains.py
+++ b/moccasin/constants/chains.py
@@ -1,0 +1,351 @@
+MAINNET = "mainnet"
+SEPOLIA = "sepolia"
+GOERLI = "goerli"
+ARBITRUM = "arbitrum"
+OPTIMISM_MAIN = "optimism-main"
+OPTIMISM_TEST = "optimism-test"
+POLYGON_MAIN = "polygon-main"
+GNOSIS_MAIN = "gnosis-main"
+GNOSIS_TEST = "gnosis-test"
+BASE_MAIN = "base-main"
+SYSCOIN = "syscoin"
+ETHEREUMCLASSIC = "ethereumclassic"
+NOVA_NETWORK = "nova-network"
+VELAS = "velas"
+THUNDERCORE = "thundercore"
+FUSE = "fuse"
+HECO = "heco"
+SHIMMER_EVM = "shimmer_evm"
+MANTA = "manta"
+ENERGYWEB = "energyweb"
+OASYS = "oasys"
+OMAX = "omax"
+FILECOIN = "filecoin"
+KUCOIN = "kucoin"
+ZKSYNC_ERA = "zksync-era"
+SEPOLIA_ZKSYNC_ERA = "sepolia-zksync-era"
+SHIDEN = "shiden"
+ROLLUX = "rollux"
+ASTAR = "astar"
+CALLISTO = "callisto"
+LYRA_CHAIN = "lyra-chain"
+BIFROST = "bifrost"
+METIS = "metis"
+POLYGON_ZKEVM = "polygon-zkevm"
+CORE = "core"
+LISK = "lisk"
+REYA_NETWORK = "reya-network"
+ONUS = "onus"
+HUBBLENET = "hubblenet"
+SANKO = "sanko"
+DOGECHAIN = "dogechain"
+MILKOMEDA = "milkomeda"
+KAVA = "kava"
+MANTLE = "mantle"
+ZETACHAIN = "zetachain"
+CELO = "celo"
+OASIS = "oasis"
+LINEA = "linea"
+BLAST = "blast"
+TAIKO = "taiko"
+SCROLL = "scroll"
+ZORA = "zora"
+NEON = "neon"
+AURORA = "aurora"
+
+CHAIN_INFO = {
+    MAINNET: {
+        "chain_id": 1,
+        "multicall2": "0x5BA1e12693Dc8F9c48aAD8770482f4739bEeD696",
+    },
+    SEPOLIA: {
+        "chain_id": 11155111,
+        "multicall2": None,
+    },
+    GOERLI: {
+        "chain_id": 5,
+        "multicall2": "0x5BA1e12693Dc8F9c48aAD8770482f4739bEeD696",
+    },
+    ARBITRUM: {
+        "chain_id": 42161,
+        "multicall2": "0x5B5CFE992AdAC0C9D48E05854B2d91C73a003858",
+    },
+    OPTIMISM_MAIN: {
+        "chain_id": 10,
+        "multicall2": "0x2DC0E2aa608532Da689e89e237dF582B783E552C",
+    },
+    OPTIMISM_TEST: {
+        "chain_id": 420,
+        "multicall2": "0x2DC0E2aa608532Da689e89e237dF582B783E552C",
+    },
+    POLYGON_MAIN: {
+        "chain_id": 137,
+        "multicall2": "0xc8E51042792d7405184DfCa245F2d27B94D013b6",
+    },
+    GNOSIS_MAIN: {
+        "chain_id": 100,
+        "multicall2": None,
+    },
+    GNOSIS_TEST: {
+        "chain_id": 10200,
+        "multicall2": None,
+    },
+    BASE_MAIN: {
+        "chain_id": 8453,
+        "multicall2": None,
+    },
+    SYSCOIN: {
+        "chain_id": 57,
+        "multicall2": None,
+    },
+    ETHEREUMCLASSIC: {
+        "chain_id": 61,
+        "multicall2": None,
+    },
+    NOVA_NETWORK: {
+        "chain_id": 87,
+        "multicall2": None,
+    },
+    VELAS: {
+        "chain_id": 106,
+        "multicall2": None,
+    },
+    THUNDERCORE: {
+        "chain_id": 108,
+        "multicall2": None,
+    },
+    FUSE: {
+        "chain_id": 122,
+        "multicall2": None,
+    },
+    HECO: {
+        "chain_id": 128,
+        "multicall2": None,
+    },
+    SHIMMER_EVM: {
+        "chain_id": 148,
+        "multicall2": None,
+    },
+    MANTA: {
+        "chain_id": 169,
+        "multicall2": None,
+    },
+    ENERGYWEB: {
+        "chain_id": 246,
+        "multicall2": None,
+    },
+    OASYS: {
+        "chain_id": 248,
+        "multicall2": None,
+    },
+    OMAX: {
+        "chain_id": 311,
+        "multicall2": None,
+    },
+    FILECOIN: {
+        "chain_id": 314,
+        "multicall2": None,
+    },
+    KUCOIN: {
+        "chain_id": 321,
+        "multicall2": None,
+    },
+    ZKSYNC_ERA: {
+        "chain_id": 324,
+        "multicall2": None,
+    },
+    SEPOLIA_ZKSYNC_ERA: {
+        "chain_id": 300,
+        "multicall2": None,
+    },
+    SHIDEN: {
+        "chain_id": 336,
+        "multicall2": None,
+    },
+    ROLLUX: {
+        "chain_id": 570,
+        "multicall2": None,
+    },
+    ASTAR: {
+        "chain_id": 592,
+        "multicall2": None,
+    },
+    CALLISTO: {
+        "chain_id": 820,
+        "multicall2": None,
+    },
+    LYRA_CHAIN: {
+        "chain_id": 957,
+        "multicall2": None,
+    },
+    BIFROST: {
+        "chain_id": 996,
+        "multicall2": None,
+    },
+    METIS: {
+        "chain_id": 1088,
+        "multicall2": None,
+    },
+    POLYGON_ZKEVM: {
+        "chain_id": 1101,
+        "multicall2": None,
+    },
+    CORE: {
+        "chain_id": 1116,
+        "multicall2": None,
+    },
+    LISK: {
+        "chain_id": 1135,
+        "multicall2": None,
+    },
+    REYA_NETWORK: {
+        "chain_id": 1729,
+        "multicall2": None,
+    },
+    ONUS: {
+        "chain_id": 1975,
+        "multicall2": None,
+    },
+    HUBBLENET: {
+        "chain_id": 1992,
+        "multicall2": None,
+    },
+    SANKO: {
+        "chain_id": 1996,
+        "multicall2": None,
+    },
+    DOGECHAIN: {
+        "chain_id": 2000,
+        "multicall2": None,
+    },
+    MILKOMEDA: {
+        "chain_id": 2001,
+        "multicall2": None,
+    },
+    KAVA: {
+        "chain_id": 2222,
+        "multicall2": None,
+    },
+    MANTLE: {
+        "chain_id": 5000,
+        "multicall2": None,
+    },
+    ZETACHAIN: {
+        "chain_id": 7000,
+        "multicall2": None,
+    },
+    CELO: {
+        "chain_id": 42220,
+        "multicall2": None,
+    },
+    OASIS: {
+        "chain_id": 42262,
+        "multicall2": None,
+    },
+    LINEA: {
+        "chain_id": 59144,
+        "multicall2": None,
+    },
+    BLAST: {
+        "chain_id": 81457,
+        "multicall2": None,
+    },
+    TAIKO: {
+        "chain_id": 167000,
+        "multicall2": None,
+    },
+    SCROLL: {
+        "chain_id": 534352,
+        "multicall2": None,
+    },
+    ZORA: {
+        "chain_id": 7777777,
+        "multicall2": None,
+    },
+    NEON: {
+        "chain_id": 245022934,
+        "multicall2": None,
+    },
+    AURORA: {
+        "chain_id": 1313161554,
+        "multicall2": None,
+    },
+}
+
+BLOCKSCOUT_EXPLORERS = {
+    MAINNET: "https://eth.blockscout.com/",
+    SEPOLIA: "https://eth-sepolia.blockscout.com/",
+    GOERLI: "https://eth-goerli.blockscout.com/",
+    ARBITRUM: "https://arbitrum.blockscout.com/",
+    OPTIMISM_MAIN: "https://optimism.blockscout.com/",
+    OPTIMISM_TEST: "https://optimism-sepolia.blockscout.com/",
+    POLYGON_MAIN: "https://polygon.blockscout.com/",
+    GNOSIS_MAIN: "https://gnosis.blockscout.com/",
+    GNOSIS_TEST: "https://gnosis-chiado.blockscout.com/",
+    BASE_MAIN: "https://base.blockscout.com/",
+    SYSCOIN: "https://explorer.syscoin.org/",
+    ETHEREUMCLASSIC: "https://etc.blockscout.com/",
+    NOVA_NETWORK: "https://explorer.novanetwork.io/",
+    VELAS: "https://evmexplorer.velas.com/",
+    THUNDERCORE: "https://explorer-mainnet.thundercore.com/",
+    FUSE: "https://explorer.fuse.io/",
+    SHIMMER_EVM: "https://explorer.evm.shimmer.network/",
+    MANTA: "https://pacific-explorer.manta.network/",
+    ENERGYWEB: "https://explorer.energyweb.org/",
+    OASYS: "https://explorer.oasys.games/",
+    FILECOIN: "https://filecoin.blockscout.com/",
+    SHIDEN: "https://shiden.blockscout.com/",
+    ROLLUX: "https://explorer.rollux.com/",
+    ASTAR: "https://astar.blockscout.com/",
+    CALLISTO: "https://explorer.callisto.network/",
+    LYRA_CHAIN: "https://explorer.lyra.finance/",
+    BIFROST: "https://explorer.mainnet.bifrostnetwork.com/",
+    METIS: "https://andromeda-explorer.metis.io/",
+    POLYGON_ZKEVM: "https://zkevm.blockscout.com/",
+    LISK: "https://blockscout.lisk.com/",
+    REYA_NETWORK: "https://explorer.reya.network/",
+    ONUS: "https://explorer.onuschain.io/",
+    SANKO: "https://explorer.sanko.xyz/",
+    DOGECHAIN: "https://explorer.dogechain.dog/",
+    MILKOMEDA: "https://explorer-mainnet-cardano-evm.c1.milkomeda.com/",
+    KAVA: "https://testnet.kavascan.com/",
+    MANTLE: "https://explorer.mantle.xyz/",
+    ZETACHAIN: "https://zetachain.blockscout.com/",
+    CELO: "https://explorer.celo.org/mainnet/",
+    OASIS: "https://explorer.emerald.oasis.dev/",
+    LINEA: "https://explorer.linea.build/",
+    BLAST: "https://blast.blockscout.com/",
+    TAIKO: "https://blockscoutapi.mainnet.taiko.xyz/",
+    SCROLL: "https://blockscout.scroll.io/",
+    ZORA: "https://explorer.zora.energy/",
+    NEON: "https://neon.blockscout.com/",
+    AURORA: "https://explorer.mainnet.aurora.dev/",
+}
+
+ZKSYNC_EXPLORERS = {
+    ZKSYNC_ERA: "https://zksync2-mainnet-explorer.zksync.io",
+    SEPOLIA_ZKSYNC_ERA: "https://explorer.sepolia.era.zksync.dev",
+}
+
+ETHERSCAN_EXPLORERS = {
+    MAINNET: "https://api.etherscan.io/api",
+    SEPOLIA: "https://api-sepolia.etherscan.io/api",
+    GOERLI: "https://api-goerli.etherscan.io/api",
+    ARBITRUM: "https://api.arbiscan.io/api",
+    OPTIMISM_MAIN: "https://api-optimistic.etherscan.io/api",
+    OPTIMISM_TEST: "https://api-goerli-optimism.etherscan.io/api",
+    POLYGON_MAIN: "https://api.polygonscan.com/api",
+    GNOSIS_MAIN: "https://api.gnosisscan.io/api",
+    BASE_MAIN: "https://api.basescan.org/api",
+    NOVA_NETWORK: "https://api-nova.arbiscan.io/api",
+    POLYGON_ZKEVM: "https://api-zkevm.polygonscan.com/api",
+    CORE: "https://api.scan.coredao.org/api",
+    CELO: "https://api.celoscan.io/api",
+    LINEA: "https://api.lineascan.build/api",
+    BLAST: "https://api.blastscan.io/api",
+    TAIKO: "https://api.taikoscan.io/api",
+    SCROLL: "https://api.scrollscan.com/api",
+    AURORA: "https://api.aurorascan.dev/api",
+}
+
+CHAIN_ID_TO_NAME = {info["chain_id"]: name for name, info in CHAIN_INFO.items()}

--- a/moccasin/constants/file_data.py
+++ b/moccasin/constants/file_data.py
@@ -185,7 +185,7 @@ anvil-zksync.log
 .DS_Store
 """
 
-COUNTER_VYPER_CONTRACT_SRC = """# pragma version 0.4.0
+COUNTER_VYPER_CONTRACT_SRC = """# pragma version 0.4.1
 # @license MIT
 
 number: public(uint256)

--- a/moccasin/constants/vars.py
+++ b/moccasin/constants/vars.py
@@ -2,6 +2,8 @@ import os
 import platform
 from pathlib import Path
 
+from moccasin.constants.chains import CHAIN_INFO, BLOCKSCOUT_EXPLORERS, ZKSYNC_EXPLORERS
+
 # File Names
 README_PATH = "README.md"
 COUNTER_CONTRACT = "Counter.vy"
@@ -114,316 +116,27 @@ SQL_AND = "AND "
 SQL_CHAIN_ID = "json_extract(tx_dict, '$.chainId') = ? "
 SQL_LIMIT = "LIMIT ? "
 
-# Networking defaults
-DEFAULT_NETWORKS_BY_NAME: dict[str, dict] = {
-    "mainnet": {
-        "explorer_uri": "https://eth.blockscout.com/",
-        "explorer_type": "blockscout",
-        "multicall2": "0x5BA1e12693Dc8F9c48aAD8770482f4739bEeD696",
-        "chain_id": 1,
-    },
-    "sepolia": {
-        "explorer_uri": "https://eth-sepolia.blockscout.com/",
-        "explorer_type": "blockscout",
-        "multicall2": None,
-        "chain_id": 11155111,
-    },
-    "goerli": {
-        "explorer_uri": "https://eth-goerli.blockscout.com/",
-        "explorer_type": "blockscout",
-        "multicall2": "0x5BA1e12693Dc8F9c48aAD8770482f4739bEeD696",
-        "chain_id": 5,
-    },
-    "arbitrum": {
-        "explorer_uri": "https://arbitrum.blockscout.com/",
-        "explorer_type": "blockscout",
-        "multicall2": "0x5B5CFE992AdAC0C9D48E05854B2d91C73a003858",
-        "chain_id": 42161,
-    },
-    "optimism-main": {
-        "explorer_uri": "https://optimism.blockscout.com/",
-        "explorer_type": "blockscout",
-        "multicall2": "0x2DC0E2aa608532Da689e89e237dF582B783E552C",
-        "chain_id": 10,
-    },
-    "optimism-test": {
-        "explorer_uri": "https://optimism-sepolia.blockscout.com/",
-        "explorer_type": "blockscout",
-        "multicall2": "0x2DC0E2aa608532Da689e89e237dF582B783E552C",
-        "chain_id": 420,
-    },
-    "polygon-main": {
-        "explorer_uri": "https://polygon.blockscout.com/",
-        "explorer_type": "blockscout",
-        "multicall2": "0xc8E51042792d7405184DfCa245F2d27B94D013b6",
-        "chain_id": 137,
-    },
-    "gnosis-main": {
-        "explorer_uri": "https://gnosis.blockscout.com/",
-        "explorer_type": "blockscout",
-        "multicall2": None,
-        "chain_id": 100,
-    },
-    "gnosis-test": {
-        "explorer_uri": "https://gnosis-chiado.blockscout.com/",
-        "explorer_type": "blockscout",
-        "multicall2": None,
-        "chain_id": 10200,
-    },
-    "base-main": {
-        "explorer_uri": "https://base.blockscout.com/",
-        "explorer_type": "blockscout",
-        "multicall2": None,
-        "chain_id": 8453,
-    },
-    "syscoin": {
-        "explorer_uri": "https://explorer.syscoin.org/",
-        "explorer_type": "blockscout",
-        "multicall2": None,
-        "chain_id": 57,
-    },
-    "ethereumclassic": {
-        "explorer_uri": "https://etc.blockscout.com/",
-        "explorer_type": "blockscout",
-        "multicall2": None,
-        "chain_id": 61,
-    },
-    "nova-network": {
-        "explorer_uri": "https://explorer.novanetwork.io/",
-        "explorer_type": "blockscout",
-        "multicall2": None,
-        "chain_id": 87,
-    },
-    "velas": {
-        "explorer_uri": "https://evmexplorer.velas.com/",
-        "explorer_type": "blockscout",
-        "multicall2": None,
-        "chain_id": 106,
-    },
-    "thundercore": {
-        "explorer_uri": "https://explorer-mainnet.thundercore.com/",
-        "explorer_type": "blockscout",
-        "multicall2": None,
-        "chain_id": 108,
-    },
-    "fuse": {
-        "explorer_uri": "https://explorer.fuse.io/",
-        "explorer_type": "blockscout",
-        "multicall2": None,
-        "chain_id": 122,
-    },
-    "heco": {"explorer_uri": None, "multicall2": None, "chain_id": 128},
-    "shimmer_evm": {
-        "explorer_uri": "https://explorer.evm.shimmer.network/",
-        "explorer_type": "blockscout",
-        "multicall2": None,
-        "chain_id": 148,
-    },
-    "manta": {
-        "explorer_uri": "https://pacific-explorer.manta.network/",
-        "explorer_type": "blockscout",
-        "multicall2": None,
-        "chain_id": 169,
-    },
-    "energyweb": {
-        "explorer_uri": "https://explorer.energyweb.org/",
-        "explorer_type": "blockscout",
-        "multicall2": None,
-        "chain_id": 246,
-    },
-    "oasys": {
-        "explorer_uri": "https://explorer.oasys.games/",
-        "explorer_type": "blockscout",
-        "multicall2": None,
-        "chain_id": 248,
-    },
-    "omax": {
-        "explorer_uri": "https://omaxscan.com/",
-        "multicall2": None,
-        "chain_id": 311,
-    },
-    "filecoin": {
-        "explorer_uri": "https://filecoin.blockscout.com/",
-        "explorer_type": "blockscout",
-        "multicall2": None,
-        "chain_id": 314,
-    },
-    "kucoin": {
-        "explorer_uri": "https://scan.kcc.io/",
-        "multicall2": None,
-        "chain_id": 321,
-    },
-    "zksync-era": {
-        "explorer_uri": "https://zksync2-mainnet-explorer.zksync.io",
-        "explorer_type": "zksyncexplorer",
-        "multicall2": None,
-        "chain_id": 324,
-    },
-    "sepolia-zksync-era": {
-        "explorer_uri": "https://explorer.sepolia.era.zksync.dev",
-        "explorer_type": "zksyncexplorer",
-        "multicall2": None,
-        "chain_id": 300,
-    },
-    "shiden": {
-        "explorer_uri": "https://shiden.blockscout.com/",
-        "explorer_type": "blockscout",
-        "multicall2": None,
-        "chain_id": 336,
-    },
-    "rollux": {
-        "explorer_uri": "https://explorer.rollux.com/",
-        "explorer_type": "blockscout",
-        "multicall2": None,
-        "chain_id": 570,
-    },
-    "astar": {
-        "explorer_uri": "https://astar.blockscout.com/",
-        "explorer_type": "blockscout",
-        "multicall2": None,
-        "chain_id": 592,
-    },
-    "callisto": {
-        "explorer_uri": "https://explorer.callisto.network/",
-        "explorer_type": "blockscout",
-        "multicall2": None,
-        "chain_id": 820,
-    },
-    "lyra-chain": {
-        "explorer_uri": "https://explorer.lyra.finance/",
-        "explorer_type": "blockscout",
-        "multicall2": None,
-        "chain_id": 957,
-    },
-    "bifrost": {
-        "explorer_uri": "https://explorer.mainnet.bifrostnetwork.com/",
-        "explorer_type": "blockscout",
-        "multicall2": None,
-        "chain_id": 996,
-    },
-    "metis": {
-        "explorer_uri": "https://andromeda-explorer.metis.io/",
-        "explorer_type": "blockscout",
-        "multicall2": None,
-        "chain_id": 1088,
-    },
-    "polygon-zkevm": {
-        "explorer_uri": "https://zkevm.blockscout.com/",
-        "explorer_type": "blockscout",
-        "multicall2": None,
-        "chain_id": 1101,
-    },
-    "core": {"explorer_uri": None, "multicall2": None, "chain_id": 1116},
-    "lisk": {
-        "explorer_uri": "https://blockscout.lisk.com/",
-        "explorer_type": "blockscout",
-        "multicall2": None,
-        "chain_id": 1135,
-    },
-    "reya-network": {
-        "explorer_uri": "https://explorer.reya.network/",
-        "explorer_type": "blockscout",
-        "multicall2": None,
-        "chain_id": 1729,
-    },
-    "onus": {
-        "explorer_uri": "https://explorer.onuschain.io/",
-        "explorer_type": "blockscout",
-        "multicall2": None,
-        "chain_id": 1975,
-    },
-    "hubblenet": {"explorer_uri": None, "multicall2": None, "chain_id": 1992},
-    "sanko": {
-        "explorer_uri": "https://explorer.sanko.xyz/",
-        "explorer_type": "blockscout",
-        "multicall2": None,
-        "chain_id": 1996,
-    },
-    "dogechain": {
-        "explorer_uri": "https://explorer.dogechain.dog/",
-        "explorer_type": "blockscout",
-        "multicall2": None,
-        "chain_id": 2000,
-    },
-    "milkomeda": {
-        "explorer_uri": "https://explorer-mainnet-cardano-evm.c1.milkomeda.com/",
-        "explorer_type": "blockscout",
-        "multicall2": None,
-        "chain_id": 2001,
-    },
-    "kava": {
-        "explorer_uri": "https://testnet.kavascan.com/",
-        "explorer_type": "blockscout",
-        "multicall2": None,
-        "chain_id": 2222,
-    },
-    "mantle": {
-        "explorer_uri": "https://explorer.mantle.xyz/",
-        "explorer_type": "blockscout",
-        "multicall2": None,
-        "chain_id": 5000,
-    },
-    "zetachain": {
-        "explorer_uri": "https://zetachain.blockscout.com/",
-        "explorer_type": "blockscout",
-        "multicall2": None,
-        "chain_id": 7000,
-    },
-    "celo": {
-        "explorer_uri": "https://explorer.celo.org/mainnet/",
-        "explorer_type": "blockscout",
-        "multicall2": None,
-        "chain_id": 42220,
-    },
-    "oasis": {
-        "explorer_uri": "https://explorer.emerald.oasis.dev/",
-        "explorer_type": "blockscout",
-        "multicall2": None,
-        "chain_id": 42262,
-    },
-    "linea": {
-        "explorer_uri": "https://explorer.linea.build/",
-        "explorer_type": "blockscout",
-        "multicall2": None,
-        "chain_id": 59144,
-    },
-    "blast": {
-        "explorer_uri": "https://blast.blockscout.com/",
-        "explorer_type": "blockscout",
-        "multicall2": None,
-        "chain_id": 81457,
-    },
-    "taiko": {
-        "explorer_uri": "https://blockscoutapi.mainnet.taiko.xyz/",
-        "explorer_type": "blockscout",
-        "multicall2": None,
-        "chain_id": 167000,
-    },
-    "scroll": {
-        "explorer_uri": "https://blockscout.scroll.io/",
-        "explorer_type": "blockscout",
-        "multicall2": None,
-        "chain_id": 534352,
-    },
-    "zora": {
-        "explorer_uri": "https://explorer.zora.energy/",
-        "explorer_type": "blockscout",
-        "multicall2": None,
-        "chain_id": 7777777,
-    },
-    "neon": {
-        "explorer_uri": "https://neon.blockscout.com/",
-        "explorer_type": "blockscout",
-        "multicall2": None,
-        "chain_id": 245022934,
-    },
-    "aurora": {
-        "explorer_uri": "https://explorer.mainnet.aurora.dev/",
-        "explorer_type": "blockscout",
-        "multicall2": None,
-        "chain_id": 1313161554,
-    },
-}
+DEFAULT_NETWORKS_BY_NAME = {}
+
+for chain_name, chain_data in CHAIN_INFO.items():
+    explorer_uri = None
+    explorer_type = None
+
+    if chain_name in BLOCKSCOUT_EXPLORERS:
+        explorer_uri = BLOCKSCOUT_EXPLORERS[chain_name]
+        explorer_type = "blockscout"
+    elif chain_name in ZKSYNC_EXPLORERS:
+        explorer_uri = ZKSYNC_EXPLORERS[chain_name]
+        explorer_type = "zksyncexplorer"
+    else:
+        continue
+
+    DEFAULT_NETWORKS_BY_NAME[chain_name] = {
+        "explorer_uri": explorer_uri,
+        "explorer_type": explorer_type,
+        "multicall2": chain_data["multicall2"],
+        "chain_id": chain_data["chain_id"],
+    }
 
 DEFAULT_NETWORKS_BY_CHAIN_ID: dict[int, dict] = {
     network["chain_id"]: {**network, "name": name}

--- a/moccasin/supported_verifiers.py
+++ b/moccasin/supported_verifiers.py
@@ -1,2 +1,3 @@
 from boa.verifiers import Blockscout  # noqa
 from boa_zksync.verifiers import ZksyncExplorer  # noqa
+from boa.explorer import Etherscan # noqa

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ authors = [
     { name = "charles-cooper", email = "3867501+charles-cooper@users.noreply.github.com" },
 ]
 dependencies = [
-    "titanoboa>=v0.2.5",
+    "titanoboa>=0.2.6",
     "python-dotenv>=1.0.1",
     "titanoboa-zksync>=0.2.9",
     "tqdm>=4.66.5",

--- a/tests/cli/deployments/conftest.py
+++ b/tests/cli/deployments/conftest.py
@@ -51,7 +51,7 @@ def deployments_config(deployments_path) -> Config:
 
 COUNTER_CONTRACT_OVERRIDE = """
 # SPDX-License-Identifier: MIT
-# pragma version 0.4.0
+# pragma version 0.4.1
 
 number: public(uint256)
 

--- a/tests/data/complex_project/contracts/BuyMeACoffee.vy
+++ b/tests/data/complex_project/contracts/BuyMeACoffee.vy
@@ -1,4 +1,4 @@
-# pragma version 0.4.0
+# pragma version 0.4.1
 # pragma enable-decimals
 # SPDX-License-Identifier: MIT
 

--- a/tests/data/complex_project/contracts/Counter.vy
+++ b/tests/data/complex_project/contracts/Counter.vy
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MIT
-# pragma version 0.4.0
+# pragma version 0.4.1
 
 number: public(uint256)
 other_number: public(uint256)

--- a/tests/data/complex_project/contracts/mocks/MockV3Aggregator.vy
+++ b/tests/data/complex_project/contracts/mocks/MockV3Aggregator.vy
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MIT
-# pragma version 0.4.0
+# pragma version 0.4.1
 
 DECIMALS: immutable(uint8)
 latestAnswer: public(int256)

--- a/tests/data/deployments_project/src/Counter.vy
+++ b/tests/data/deployments_project/src/Counter.vy
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MIT
-# pragma version 0.4.0
+# pragma version 0.4.1
 
 number: public(uint256)
 

--- a/tests/data/deployments_project/src/mocks/MockV3Aggregator.vy
+++ b/tests/data/deployments_project/src/mocks/MockV3Aggregator.vy
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MIT
-# pragma version 0.4.0
+# pragma version 0.4.1
 
 DECIMALS: immutable(uint8)
 latestAnswer: public(int256)

--- a/tests/data/installation_project/src/Counter.vy
+++ b/tests/data/installation_project/src/Counter.vy
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MIT
-# pragma version 0.4.0
+# pragma version 0.4.1
 
 number: public(uint256)
 

--- a/tests/data/no_config_project/contracts/hi.vy
+++ b/tests/data/no_config_project/contracts/hi.vy
@@ -1,4 +1,4 @@
 # SPDX-License-Identifier: MIT
-# pragma version 0.4.0
+# pragma version 0.4.1
 
 hi: public(uint256)

--- a/tests/data/purge_project/lib/github/patrickalphac/test_repo/src/Counter.vy
+++ b/tests/data/purge_project/lib/github/patrickalphac/test_repo/src/Counter.vy
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MIT
-# pragma version 0.4.0
+# pragma version 0.4.1
 
 number: public(uint256)
 

--- a/tests/data/purge_project/src/Counter.vy
+++ b/tests/data/purge_project/src/Counter.vy
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MIT
-# pragma version 0.4.0
+# pragma version 0.4.1
 
 number: public(uint256)
 

--- a/tests/data/tests_project/src/Counter.vy
+++ b/tests/data/tests_project/src/Counter.vy
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MIT
-# pragma version 0.4.0
+# pragma version 0.4.1
 
 number: public(uint256)
 

--- a/tests/data/zksync_project/src/Difficulty.vy
+++ b/tests/data/zksync_project/src/Difficulty.vy
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MIT
-# pragma version 0.4.0
+# pragma version 0.4.1
 
 # Should return 2500000000000000
 @external 

--- a/tests/data/zksync_project/src/SelfDestruct.vy
+++ b/tests/data/zksync_project/src/SelfDestruct.vy
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MIT
-# pragma version 0.4.0
+# pragma version 0.4.1
 
 @deploy
 def __init__():

--- a/uv.lock
+++ b/uv.lock
@@ -288,6 +288,18 @@ wheels = [
 ]
 
 [[package]]
+name = "click"
+version = "8.1.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b9/2e/0090cbf739cee7d23781ad4b89a9894a41538e4fcf4c31dcdd705b78eb8b/click-8.1.8.tar.gz", hash = "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a", size = 226593 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/d4/7ebdbd03970677812aac39c869717059dbb71a4cfc033ca6e5221787892c/click-8.1.8-py3-none-any.whl", hash = "sha256:63c132bbbed01578a06712a2d1f497bb62d9c1c0d329b7903a866228027263b2", size = 98188 },
+]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
@@ -613,6 +625,18 @@ wheels = [
 ]
 
 [[package]]
+name = "ghp-import"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "python-dateutil" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d9/29/d40217cbe2f6b1359e00c6c307bb3fc876ba74068cbab3dde77f03ca0dc4/ghp-import-2.1.0.tar.gz", hash = "sha256:9c535c4c61193c2df8871222567d7fd7e5014d835f97dc7b7439069e2413d343", size = 10943 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f7/ec/67fbef5d497f86283db54c22eec6f6140243aae73265799baaaa19cd17fb/ghp_import-2.1.0-py3-none-any.whl", hash = "sha256:8337dd7b50877f163d4c0289bc1f1c7f127550241988d568c1db512c4324a619", size = 11034 },
+]
+
+[[package]]
 name = "hexbytes"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -678,7 +702,7 @@ name = "ipykernel"
 version = "6.29.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "appnope", marker = "platform_system == 'Darwin'" },
+    { name = "appnope", marker = "sys_platform == 'darwin'" },
     { name = "comm" },
     { name = "debugpy" },
     { name = "ipython" },
@@ -773,6 +797,15 @@ wheels = [
 ]
 
 [[package]]
+name = "lark"
+version = "1.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/af/60/bc7622aefb2aee1c0b4ba23c1446d3e30225c8770b38d7aedbfb65ca9d5a/lark-1.2.2.tar.gz", hash = "sha256:ca807d0162cd16cef15a8feecb862d7319e7a09bdb13aef927968e45040fed80", size = 252132 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2d/00/d90b10b962b4277f5e64a78b6609968859ff86889f5b898c1a778c06ec00/lark-1.2.2-py3-none-any.whl", hash = "sha256:c2276486b02f0f1b90be155f2c8ba4a8e194d42775786db622faccd652d8e80c", size = 111036 },
+]
+
+[[package]]
 name = "lru-dict"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -804,6 +837,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/5a/0b/e30236aafe31b4247aa9ae61ba8aac6dde75c3ea0e47a8fb7eef53f6d5ce/lru_dict-1.3.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:0e88dba16695f17f41701269fa046197a3fd7b34a8dba744c8749303ddaa18df", size = 37143 },
     { url = "https://files.pythonhosted.org/packages/1c/28/b59bcebb8d76ba8147a784a8be7eab6a4ad3395b9236e73740ff675a5a52/lru_dict-1.3.0-cp312-cp312-win32.whl", hash = "sha256:6ffaf595e625b388babc8e7d79b40f26c7485f61f16efe76764e32dce9ea17fc", size = 12653 },
     { url = "https://files.pythonhosted.org/packages/bd/18/06d9710cb0a0d3634f8501e4bdcc07abe64a32e404d82895a6a36fab97f6/lru_dict-1.3.0-cp312-cp312-win_amd64.whl", hash = "sha256:cf9da32ef2582434842ab6ba6e67290debfae72771255a8e8ab16f3e006de0aa", size = 13811 },
+]
+
+[[package]]
+name = "markdown"
+version = "3.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/54/28/3af612670f82f4c056911fbbbb42760255801b3068c48de792d354ff4472/markdown-3.7.tar.gz", hash = "sha256:2ae2471477cfd02dbbf038d5d9bc226d40def84b4fe2986e49b59b6b472bbed2", size = 357086 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/08/83871f3c50fc983b88547c196d11cf8c3340e37c32d2e9d6152abe2c61f7/Markdown-3.7-py3-none-any.whl", hash = "sha256:7eb6df5690b81a1d7942992c97fad2938e956e79df20cbc6186e9c3a77b1c803", size = 106349 },
 ]
 
 [[package]]
@@ -888,6 +930,84 @@ wheels = [
 ]
 
 [[package]]
+name = "mergedeep"
+version = "1.3.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3a/41/580bb4006e3ed0361b8151a01d324fb03f420815446c7def45d02f74c270/mergedeep-1.3.4.tar.gz", hash = "sha256:0096d52e9dad9939c3d975a774666af186eda617e6ca84df4c94dec30004f2a8", size = 4661 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/19/04f9b178c2d8a15b076c8b5140708fa6ffc5601fb6f1e975537072df5b2a/mergedeep-1.3.4-py3-none-any.whl", hash = "sha256:70775750742b25c0d8f36c55aed03d24c3384d17c951b3175d898bd778ef0307", size = 6354 },
+]
+
+[[package]]
+name = "mkdocs"
+version = "1.6.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "ghp-import" },
+    { name = "jinja2" },
+    { name = "markdown" },
+    { name = "markupsafe" },
+    { name = "mergedeep" },
+    { name = "mkdocs-get-deps" },
+    { name = "packaging" },
+    { name = "pathspec" },
+    { name = "pyyaml" },
+    { name = "pyyaml-env-tag" },
+    { name = "watchdog" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bc/c6/bbd4f061bd16b378247f12953ffcb04786a618ce5e904b8c5a01a0309061/mkdocs-1.6.1.tar.gz", hash = "sha256:7b432f01d928c084353ab39c57282f29f92136665bdd6abf7c1ec8d822ef86f2", size = 3889159 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/22/5b/dbc6a8cddc9cfa9c4971d59fb12bb8d42e161b7e7f8cc89e49137c5b279c/mkdocs-1.6.1-py3-none-any.whl", hash = "sha256:db91759624d1647f3f34aa0c3f327dd2601beae39a366d6e064c03468d35c20e", size = 3864451 },
+]
+
+[[package]]
+name = "mkdocs-get-deps"
+version = "0.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mergedeep" },
+    { name = "platformdirs" },
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/98/f5/ed29cd50067784976f25ed0ed6fcd3c2ce9eb90650aa3b2796ddf7b6870b/mkdocs_get_deps-0.2.0.tar.gz", hash = "sha256:162b3d129c7fad9b19abfdcb9c1458a651628e4b1dea628ac68790fb3061c60c", size = 10239 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9f/d4/029f984e8d3f3b6b726bd33cafc473b75e9e44c0f7e80a5b29abc466bdea/mkdocs_get_deps-0.2.0-py3-none-any.whl", hash = "sha256:2bf11d0b133e77a0dd036abeeb06dec8775e46efa526dc70667d8863eefc6134", size = 9521 },
+]
+
+[[package]]
+name = "mkdocs-material"
+version = "9.5.41"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "babel" },
+    { name = "colorama" },
+    { name = "jinja2" },
+    { name = "markdown" },
+    { name = "mkdocs" },
+    { name = "mkdocs-material-extensions" },
+    { name = "paginate" },
+    { name = "pygments" },
+    { name = "pymdown-extensions" },
+    { name = "regex" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ab/56/c58fe932fe0b3e70b065f1ce5759672c81ae91d00b720023ab8cd580b7a8/mkdocs_material-9.5.41.tar.gz", hash = "sha256:30fa5d459b4b8130848ecd8e1c908878345d9d8268f7ddbc31eebe88d462d97b", size = 3963765 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/bd/92771ccb61285dacfe852f96c08601f9b4830a3e1647ccc9726588b3340b/mkdocs_material-9.5.41-py3-none-any.whl", hash = "sha256:990bc138c33342b5b73e7545915ebc0136e501bfbd8e365735144f5120891d83", size = 8672461 },
+]
+
+[[package]]
+name = "mkdocs-material-extensions"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/79/9b/9b4c96d6593b2a541e1cb8b34899a6d021d208bb357042823d4d2cabdbe7/mkdocs_material_extensions-1.3.1.tar.gz", hash = "sha256:10c9511cea88f568257f960358a467d12b970e1f7b2c0e5fb2bb48cab1928443", size = 11847 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5b/54/662a4743aa81d9582ee9339d4ffa3c8fd40a4965e033d77b9da9774d3960/mkdocs_material_extensions-1.3.1-py3-none-any.whl", hash = "sha256:adff8b62700b25cb77b53358dad940f3ef973dd6db797907c49e3c2ef3ab4e31", size = 8728 },
+]
+
+[[package]]
 name = "moccasin"
 version = "0.3.8"
 source = { editable = "." }
@@ -938,7 +1058,7 @@ requires-dist = [
     { name = "sphinx-copybutton", marker = "extra == 'docs'", specifier = ">=0.5.2" },
     { name = "sphinx-multiversion", marker = "extra == 'docs'", specifier = ">=0.2.4" },
     { name = "sphinx-tabs", marker = "extra == 'docs'", specifier = ">=3.4.5" },
-    { name = "titanoboa", specifier = ">=0.2.5" },
+    { name = "titanoboa", specifier = ">=0.2.6" },
     { name = "titanoboa-zksync", specifier = ">=0.2.9" },
     { name = "tomli-w", specifier = ">=1.0.0" },
     { name = "tomlkit", specifier = ">=0.13.2" },
@@ -1017,6 +1137,15 @@ wheels = [
 ]
 
 [[package]]
+name = "paginate"
+version = "0.5.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ec/46/68dde5b6bc00c1296ec6466ab27dddede6aec9af1b99090e1107091b3b84/paginate-0.5.7.tar.gz", hash = "sha256:22bd083ab41e1a8b4f3690544afb2c60c25e5c9a63a30fa2f483f6c60c8e5945", size = 19252 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/90/96/04b8e52da071d28f5e21a805b19cb9390aa17a47462ac87f5e2696b9566d/paginate-0.5.7-py2.py3-none-any.whl", hash = "sha256:b885e2af73abcf01d9559fd5216b57ef722f8c42affbb63942377668e35c7591", size = 13746 },
+]
+
+[[package]]
 name = "parsimonious"
 version = "0.10.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1035,6 +1164,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/66/94/68e2e17afaa9169cf6412ab0f28623903be73d1b32e208d9e8e541bb086d/parso-0.8.4.tar.gz", hash = "sha256:eb3a7b58240fb99099a345571deecc0f9540ea5f4dd2fe14c2a99d6b281ab92d", size = 400609 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c6/ac/dac4a63f978e4dcb3c6d3a78c4d8e0192a113d288502a1216950c41b1027/parso-0.8.4-py2.py3-none-any.whl", hash = "sha256:a418670a20291dacd2dddc80c377c5c3791378ee1e8d12bffc35420643d43f18", size = 103650 },
+]
+
+[[package]]
+name = "pathspec"
+version = "0.12.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ca/bc/f35b8446f4531a7cb215605d100cd88b7ac6f44ab3fc94870c120ab3adbf/pathspec-0.12.1.tar.gz", hash = "sha256:a482d51503a1ab33b1c67a6c3813a26953dbdc71c31dacaef9a838c4e29f5712", size = 51043 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cc/20/ff623b09d963f88bfde16306a54e12ee5ea43e9b597108672ff3a408aad6/pathspec-0.12.1-py3-none-any.whl", hash = "sha256:a0d503e138a4c123b27490a4f7beda6a01c6f288df0e4a8b79c7eb0dc7b4cc08", size = 31191 },
 ]
 
 [[package]]
@@ -1172,8 +1310,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/39/1b/d0b013bf7d1af7cf0a6a4fce13f5fe5813ab225313755367b36e714a63f8/pycryptodome-3.21.0-cp36-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:18caa8cfbc676eaaf28613637a89980ad2fd96e00c564135bf90bc3f0b34dd93", size = 2254397 },
     { url = "https://files.pythonhosted.org/packages/14/71/4cbd3870d3e926c34706f705d6793159ac49d9a213e3ababcdade5864663/pycryptodome-3.21.0-cp36-abi3-win32.whl", hash = "sha256:280b67d20e33bb63171d55b1067f61fbd932e0b1ad976b3a184303a3dad22764", size = 1775641 },
     { url = "https://files.pythonhosted.org/packages/43/1d/81d59d228381576b92ecede5cd7239762c14001a828bdba30d64896e9778/pycryptodome-3.21.0-cp36-abi3-win_amd64.whl", hash = "sha256:b7aa25fc0baa5b1d95b7633af4f5f1838467f1815442b22487426f94e0d66c53", size = 1812863 },
-    { url = "https://files.pythonhosted.org/packages/25/b3/09ff7072e6d96c9939c24cf51d3c389d7c345bf675420355c22402f71b68/pycryptodome-3.21.0-pp27-pypy_73-manylinux2010_x86_64.whl", hash = "sha256:2cb635b67011bc147c257e61ce864879ffe6d03342dc74b6045059dfbdedafca", size = 1691593 },
-    { url = "https://files.pythonhosted.org/packages/a8/91/38e43628148f68ba9b68dedbc323cf409e537fd11264031961fd7c744034/pycryptodome-3.21.0-pp27-pypy_73-win32.whl", hash = "sha256:4c26a2f0dc15f81ea3afa3b0c87b87e501f235d332b7f27e2225ecb80c0b1cdd", size = 1765997 },
 ]
 
 [[package]]
@@ -1253,6 +1389,19 @@ wheels = [
 ]
 
 [[package]]
+name = "pymdown-extensions"
+version = "10.14.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown" },
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7c/44/e6de2fdc880ad0ec7547ca2e087212be815efbc9a425a8d5ba9ede602cbb/pymdown_extensions-10.14.3.tar.gz", hash = "sha256:41e576ce3f5d650be59e900e4ceff231e0aed2a88cf30acaee41e02f063a061b", size = 846846 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/eb/f5/b9e2a42aa8f9e34d52d66de87941ecd236570c7ed2e87775ed23bbe4e224/pymdown_extensions-10.14.3-py3-none-any.whl", hash = "sha256:05e0bee73d64b9c71a4ae17c72abc2f700e8bc8403755a00580b49a4e9f189e9", size = 264467 },
+]
+
+[[package]]
 name = "pytest"
 version = "8.3.4"
 source = { registry = "https://pypi.org/simple" }
@@ -1328,6 +1477,53 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a9/a4/aa562d8935e3df5e49c161b427a3a2efad2ed4e9cf81c3de636f1fdddfd0/pywin32-308-cp313-cp313-win32.whl", hash = "sha256:1c44539a37a5b7b21d02ab34e6a4d314e0788f1690d65b48e9b0b89f31abbbed", size = 5938579 },
     { url = "https://files.pythonhosted.org/packages/c7/50/b0efb8bb66210da67a53ab95fd7a98826a97ee21f1d22949863e6d588b22/pywin32-308-cp313-cp313-win_amd64.whl", hash = "sha256:fd380990e792eaf6827fcb7e187b2b4b1cede0585e3d0c9e84201ec27b9905e4", size = 6542056 },
     { url = "https://files.pythonhosted.org/packages/26/df/2b63e3e4f2df0224f8aaf6d131f54fe4e8c96400eb9df563e2aae2e1a1f9/pywin32-308-cp313-cp313-win_arm64.whl", hash = "sha256:ef313c46d4c18dfb82a2431e3051ac8f112ccee1a34f29c263c583c568db63cd", size = 7974986 },
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/54/ed/79a089b6be93607fa5cdaedf301d7dfb23af5f25c398d5ead2525b063e17/pyyaml-6.0.2.tar.gz", hash = "sha256:d584d9ec91ad65861cc08d42e834324ef890a082e591037abe114850ff7bbc3e", size = 130631 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f8/aa/7af4e81f7acba21a4c6be026da38fd2b872ca46226673c89a758ebdc4fd2/PyYAML-6.0.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:cc1c1159b3d456576af7a3e4d1ba7e6924cb39de8f67111c735f6fc832082774", size = 184612 },
+    { url = "https://files.pythonhosted.org/packages/8b/62/b9faa998fd185f65c1371643678e4d58254add437edb764a08c5a98fb986/PyYAML-6.0.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:1e2120ef853f59c7419231f3bf4e7021f1b936f6ebd222406c3b60212205d2ee", size = 172040 },
+    { url = "https://files.pythonhosted.org/packages/ad/0c/c804f5f922a9a6563bab712d8dcc70251e8af811fce4524d57c2c0fd49a4/PyYAML-6.0.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5d225db5a45f21e78dd9358e58a98702a0302f2659a3c6cd320564b75b86f47c", size = 736829 },
+    { url = "https://files.pythonhosted.org/packages/51/16/6af8d6a6b210c8e54f1406a6b9481febf9c64a3109c541567e35a49aa2e7/PyYAML-6.0.2-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5ac9328ec4831237bec75defaf839f7d4564be1e6b25ac710bd1a96321cc8317", size = 764167 },
+    { url = "https://files.pythonhosted.org/packages/75/e4/2c27590dfc9992f73aabbeb9241ae20220bd9452df27483b6e56d3975cc5/PyYAML-6.0.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3ad2a3decf9aaba3d29c8f537ac4b243e36bef957511b4766cb0057d32b0be85", size = 762952 },
+    { url = "https://files.pythonhosted.org/packages/9b/97/ecc1abf4a823f5ac61941a9c00fe501b02ac3ab0e373c3857f7d4b83e2b6/PyYAML-6.0.2-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:ff3824dc5261f50c9b0dfb3be22b4567a6f938ccce4587b38952d85fd9e9afe4", size = 735301 },
+    { url = "https://files.pythonhosted.org/packages/45/73/0f49dacd6e82c9430e46f4a027baa4ca205e8b0a9dce1397f44edc23559d/PyYAML-6.0.2-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:797b4f722ffa07cc8d62053e4cff1486fa6dc094105d13fea7b1de7d8bf71c9e", size = 756638 },
+    { url = "https://files.pythonhosted.org/packages/22/5f/956f0f9fc65223a58fbc14459bf34b4cc48dec52e00535c79b8db361aabd/PyYAML-6.0.2-cp311-cp311-win32.whl", hash = "sha256:11d8f3dd2b9c1207dcaf2ee0bbbfd5991f571186ec9cc78427ba5bd32afae4b5", size = 143850 },
+    { url = "https://files.pythonhosted.org/packages/ed/23/8da0bbe2ab9dcdd11f4f4557ccaf95c10b9811b13ecced089d43ce59c3c8/PyYAML-6.0.2-cp311-cp311-win_amd64.whl", hash = "sha256:e10ce637b18caea04431ce14fabcf5c64a1c61ec9c56b071a4b7ca131ca52d44", size = 161980 },
+    { url = "https://files.pythonhosted.org/packages/86/0c/c581167fc46d6d6d7ddcfb8c843a4de25bdd27e4466938109ca68492292c/PyYAML-6.0.2-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:c70c95198c015b85feafc136515252a261a84561b7b1d51e3384e0655ddf25ab", size = 183873 },
+    { url = "https://files.pythonhosted.org/packages/a8/0c/38374f5bb272c051e2a69281d71cba6fdb983413e6758b84482905e29a5d/PyYAML-6.0.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ce826d6ef20b1bc864f0a68340c8b3287705cae2f8b4b1d932177dcc76721725", size = 173302 },
+    { url = "https://files.pythonhosted.org/packages/c3/93/9916574aa8c00aa06bbac729972eb1071d002b8e158bd0e83a3b9a20a1f7/PyYAML-6.0.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1f71ea527786de97d1a0cc0eacd1defc0985dcf6b3f17bb77dcfc8c34bec4dc5", size = 739154 },
+    { url = "https://files.pythonhosted.org/packages/95/0f/b8938f1cbd09739c6da569d172531567dbcc9789e0029aa070856f123984/PyYAML-6.0.2-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9b22676e8097e9e22e36d6b7bda33190d0d400f345f23d4065d48f4ca7ae0425", size = 766223 },
+    { url = "https://files.pythonhosted.org/packages/b9/2b/614b4752f2e127db5cc206abc23a8c19678e92b23c3db30fc86ab731d3bd/PyYAML-6.0.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:80bab7bfc629882493af4aa31a4cfa43a4c57c83813253626916b8c7ada83476", size = 767542 },
+    { url = "https://files.pythonhosted.org/packages/d4/00/dd137d5bcc7efea1836d6264f049359861cf548469d18da90cd8216cf05f/PyYAML-6.0.2-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:0833f8694549e586547b576dcfaba4a6b55b9e96098b36cdc7ebefe667dfed48", size = 731164 },
+    { url = "https://files.pythonhosted.org/packages/c9/1f/4f998c900485e5c0ef43838363ba4a9723ac0ad73a9dc42068b12aaba4e4/PyYAML-6.0.2-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8b9c7197f7cb2738065c481a0461e50ad02f18c78cd75775628afb4d7137fb3b", size = 756611 },
+    { url = "https://files.pythonhosted.org/packages/df/d1/f5a275fdb252768b7a11ec63585bc38d0e87c9e05668a139fea92b80634c/PyYAML-6.0.2-cp312-cp312-win32.whl", hash = "sha256:ef6107725bd54b262d6dedcc2af448a266975032bc85ef0172c5f059da6325b4", size = 140591 },
+    { url = "https://files.pythonhosted.org/packages/0c/e8/4f648c598b17c3d06e8753d7d13d57542b30d56e6c2dedf9c331ae56312e/PyYAML-6.0.2-cp312-cp312-win_amd64.whl", hash = "sha256:7e7401d0de89a9a855c839bc697c079a4af81cf878373abd7dc625847d25cbd8", size = 156338 },
+    { url = "https://files.pythonhosted.org/packages/ef/e3/3af305b830494fa85d95f6d95ef7fa73f2ee1cc8ef5b495c7c3269fb835f/PyYAML-6.0.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:efdca5630322a10774e8e98e1af481aad470dd62c3170801852d752aa7a783ba", size = 181309 },
+    { url = "https://files.pythonhosted.org/packages/45/9f/3b1c20a0b7a3200524eb0076cc027a970d320bd3a6592873c85c92a08731/PyYAML-6.0.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:50187695423ffe49e2deacb8cd10510bc361faac997de9efef88badc3bb9e2d1", size = 171679 },
+    { url = "https://files.pythonhosted.org/packages/7c/9a/337322f27005c33bcb656c655fa78325b730324c78620e8328ae28b64d0c/PyYAML-6.0.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0ffe8360bab4910ef1b9e87fb812d8bc0a308b0d0eef8c8f44e0254ab3b07133", size = 733428 },
+    { url = "https://files.pythonhosted.org/packages/a3/69/864fbe19e6c18ea3cc196cbe5d392175b4cf3d5d0ac1403ec3f2d237ebb5/PyYAML-6.0.2-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:17e311b6c678207928d649faa7cb0d7b4c26a0ba73d41e99c4fff6b6c3276484", size = 763361 },
+    { url = "https://files.pythonhosted.org/packages/04/24/b7721e4845c2f162d26f50521b825fb061bc0a5afcf9a386840f23ea19fa/PyYAML-6.0.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:70b189594dbe54f75ab3a1acec5f1e3faa7e8cf2f1e08d9b561cb41b845f69d5", size = 759523 },
+    { url = "https://files.pythonhosted.org/packages/2b/b2/e3234f59ba06559c6ff63c4e10baea10e5e7df868092bf9ab40e5b9c56b6/PyYAML-6.0.2-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:41e4e3953a79407c794916fa277a82531dd93aad34e29c2a514c2c0c5fe971cc", size = 726660 },
+    { url = "https://files.pythonhosted.org/packages/fe/0f/25911a9f080464c59fab9027482f822b86bf0608957a5fcc6eaac85aa515/PyYAML-6.0.2-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:68ccc6023a3400877818152ad9a1033e3db8625d899c72eacb5a668902e4d652", size = 751597 },
+    { url = "https://files.pythonhosted.org/packages/14/0d/e2c3b43bbce3cf6bd97c840b46088a3031085179e596d4929729d8d68270/PyYAML-6.0.2-cp313-cp313-win32.whl", hash = "sha256:bc2fa7c6b47d6bc618dd7fb02ef6fdedb1090ec036abab80d4681424b84c1183", size = 140527 },
+    { url = "https://files.pythonhosted.org/packages/fa/de/02b54f42487e3d3c6efb3f89428677074ca7bf43aae402517bc7cca949f3/PyYAML-6.0.2-cp313-cp313-win_amd64.whl", hash = "sha256:8388ee1976c416731879ac16da0aff3f63b286ffdd57cdeb95f3f2e085687563", size = 156446 },
+]
+
+[[package]]
+name = "pyyaml-env-tag"
+version = "0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fb/8e/da1c6c58f751b70f8ceb1eb25bc25d524e8f14fe16edcce3f4e3ba08629c/pyyaml_env_tag-0.1.tar.gz", hash = "sha256:70092675bda14fdec33b31ba77e7543de9ddc88f2e5b99160396572d11525bdb", size = 5631 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/66/bbb1dd374f5c870f59c5bb1db0e18cbe7fa739415a24cbd95b2d1f5ae0c4/pyyaml_env_tag-0.1-py3-none-any.whl", hash = "sha256:af31106dec8a4d68c60207c1886031cbf839b68aa7abccdb19868200532c2069", size = 3911 },
 ]
 
 [[package]]
@@ -1701,7 +1897,7 @@ wheels = [
 
 [[package]]
 name = "titanoboa"
-version = "0.2.5"
+version = "0.2.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "eth-abi" },
@@ -1709,6 +1905,7 @@ dependencies = [
     { name = "eth-stdlib" },
     { name = "eth-typing" },
     { name = "hypothesis" },
+    { name = "mkdocs-material" },
     { name = "py-evm" },
     { name = "pytest" },
     { name = "pytest-cov" },
@@ -1718,9 +1915,9 @@ dependencies = [
     { name = "vvm" },
     { name = "vyper" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/72/b9/dd934b73f02fe802e3cb00f103e91e75e66f2d96271033b101212bcae4c0/titanoboa-0.2.5.tar.gz", hash = "sha256:734830569296e851255ddc4925359a9a25f040a4a41f88fe3682a456faa3c662", size = 91978 }
+sdist = { url = "https://files.pythonhosted.org/packages/51/0d/cccf3b3cde2eb69ac76f4737fcee9c7045a294c402227a22d12736f8dba2/titanoboa-0.2.6.tar.gz", hash = "sha256:6bbf0063bfc5d7ffab5044da53e23564fcb4cf5cfe39b1e31a2c01df8ccb96e0", size = 99448 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ce/c5/315e398f5209e300cde62291f196485fee720269d953f65bdb9114d78fc3/titanoboa-0.2.5-py3-none-any.whl", hash = "sha256:e678aad87408ae5a664a9cb71b886cb23b95e6204141044ccd8fe3bc97b4e14f", size = 103011 },
+    { url = "https://files.pythonhosted.org/packages/c2/03/1636b511faefb99448180c18a33c3e6b04dcc92e7e8900ab4e086ad70067/titanoboa-0.2.6-py3-none-any.whl", hash = "sha256:63bee3b97428697fa2f269c2d2ecbc763b372dc774e3f6229c90f32827bd1967", size = 111043 },
 ]
 
 [[package]]
@@ -1824,7 +2021,7 @@ name = "tqdm"
 version = "4.67.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "platform_system == 'Windows'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a8/4b/29b4ef32e036bb34e4ab51796dd745cdba7ed47ad142a9f4a1eb8e0c744d/tqdm-4.67.1.tar.gz", hash = "sha256:f8aef9c52c08c13a65f30ea34f4e5aac3fd1a34959879d7e59e63027286627f2", size = 169737 }
 wheels = [
@@ -1914,19 +2111,20 @@ wheels = [
 
 [[package]]
 name = "vyper"
-version = "0.4.0"
+version = "0.4.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "asttokens" },
     { name = "cbor2" },
     { name = "importlib-metadata" },
+    { name = "lark" },
     { name = "packaging" },
     { name = "pycryptodome" },
     { name = "wheel" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2b/09/befae43f33161cf817590337f5ea12e8849e401eaaca9eeea22852ae90d1/vyper-0.4.0.tar.gz", hash = "sha256:9687145c6a0bf42de52e92202ce9a913648d3c657ac8e5cfb9b35a100dc47e34", size = 672136 }
+sdist = { url = "https://files.pythonhosted.org/packages/b3/f1/3848bc040c2715bf77e80cc8cd03359257a959d9cf4a037a3506804cb995/vyper-0.4.1.tar.gz", hash = "sha256:2a219b895c9b5ad6a71237a6fb7d03a6eccaa800faa30ba32418847e350a95e3", size = 734208 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/37/0b/7c14ae8aec83187a67d8c13a4fdff9bc4d72d9ef822ec7ce026b301a00cb/vyper-0.4.0-py3-none-any.whl", hash = "sha256:22d7e1eca229e95a909dc971ff5b1685c8379404e3fc3b7b84dbc59b5de1c262", size = 338856 },
+    { url = "https://files.pythonhosted.org/packages/2f/3f/fb474ea7f3e00a16fb23ea01e1844977e450aca7962e7ad9d11badb61683/vyper-0.4.1-py3-none-any.whl", hash = "sha256:b22e19e20557b3c13fa2721efabc4e926f624af9a3bd328e1da8fb6b727d908f", size = 370776 },
 ]
 
 [[package]]


### PR DESCRIPTION
titanoboa v0.2.6 finally added support for contract verification on Etherscan ([https://github.com/vyperlang/titanoboa/pull/330/files](https://github.com/vyperlang/titanoboa/pull/330/files)) 
This PR add supports for etherscan verification to moccasin. Likely dependent on #227 ?
