### PR TITLE
Update setup-uv action to latest version v6

### DIFF
--- a/.github/workflows/docs-release.yml
+++ b/.github/workflows/docs-release.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
       - name: Install uv
-        uses: astral-sh/setup-uv@v2
+        uses: astral-sh/setup-uv@v6
       - name: Setup just
         uses: extractions/setup-just@v2
       - name: Sphinx build

--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           python-version-file: "pyproject.toml"
       - name: Install uv
-        uses: astral-sh/setup-uv@v2
+        uses: astral-sh/setup-uv@v6
       - name: Install dependencies
         run: uv sync
       - name: Build package

--- a/.github/workflows/typecheck-and-formatting.yml
+++ b/.github/workflows/typecheck-and-formatting.yml
@@ -15,7 +15,7 @@ jobs:
       with:
         python-version-file: "pyproject.toml"
     - name: Install uv
-      uses: astral-sh/setup-uv@v2
+      uses: astral-sh/setup-uv@v6
     - name: Install dependencies
       run: uv sync --dev
     - name: Setup just
@@ -33,7 +33,7 @@ jobs:
       with:
         python-version-file: "pyproject.toml"
     - name: Install uv
-      uses: astral-sh/setup-uv@v2
+      uses: astral-sh/setup-uv@v6
     - name: Install dependencies
       run: uv sync --dev
     - name: Setup just


### PR DESCRIPTION
Updated astral-sh/setup-uv from v2 to v6 across all workflow files to ensure compatibility with the latest features and improvements. 