### PR TITLE
docs: fix minor language issues in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Fast to install, test, and run python commands on your smart contracts.
 
 # Quickstart
 
-Head over to [the moccasin installation documentation](https://cyfrin.github.io/moccasin/installing_moccasin.html) to for other install methodologies and getting stated.
+Head over to [the moccasin installation documentation](https://cyfrin.github.io/moccasin/installing_moccasin.html) for other install methodologies and getting started.
 
 ## This README Quickstart
 


### PR DESCRIPTION
corrected a couple of small language issues in the documentation. specifically:  
- removed the extra "to" in the phrase "to for."  
- corrected "stated" to "started" for proper tense usage.  
