### PR TITLE
feat: replace temp file for vvm error

### DIFF
--- a/moccasin/_error_utils.py
+++ b/moccasin/_error_utils.py
@@ -1,6 +1,7 @@
 import re
-from pathlib import Path
+import tempfile
 
+from pathlib import Path
 from vvm.exceptions import VyperError as VVMVyperError
 
 
@@ -11,13 +12,18 @@ def handle_vvm_error(error: VVMVyperError, contract_path: Path) -> None:
     @raises VVMVyperError: Raises a modified VVMVyperError with the updated error message.
     """
     original_stderr = error.stderr_data
-    temporary_path_pattern = r'contract "/tmp/vyper-[a-zA-Z0-9_-]+\.vy:(\d+)"'
-    replacement_string = f'contract "{str(contract_path)}:\\1"'
+    # @dev tempfile.gettempdir() retrieves the system's standard temporary directory path.
+    # @dev re.escape() to ensure that any special characters in the temporary directory path are treated literally in the regular expression.
+    temporary_path_pattern = (
+        re.escape(tempfile.gettempdir()) + r"[/\\]vyper-[a-zA-Z0-9_-]+\.vy:(\d+)"
+    )
+    replacement_string = f"{str(contract_path)}:\\1"
 
     # Replace the temporary path with the actual contract path
     modified_stderr = re.sub(
         temporary_path_pattern, replacement_string, original_stderr
     )
+
     raise VVMVyperError(
         stderr_data=modified_stderr,
         stdout_data=error.stdout_data,

--- a/moccasin/_error_utils.py
+++ b/moccasin/_error_utils.py
@@ -1,0 +1,28 @@
+import re
+
+from pathlib import Path
+from vvm.exceptions import VyperError as VVMVyperError
+
+def handle_vvm_error(
+    error: VVMVyperError,
+    contract_path: Path,
+) -> None:
+    """Handle VVM errors by adapting the error message and raising the exception.
+    @param error: The VVMVyperError instance to handle.
+    @param contract_path: The path to the contract file.
+    @raises VVMVyperError: Raises a modified VVMVyperError with the updated error message.
+    """
+    original_stderr = error.stderr_data
+    temporary_path_pattern = r'contract "/tmp/vyper-[a-zA-Z0-9]+\.vy:(\d+)"'
+    replacement_string = f'contract "{str(contract_path)}:\\1"'
+
+    # Replace the temporary path with the actual contract path
+    modified_stderr = re.sub(
+        temporary_path_pattern, replacement_string, original_stderr
+    )
+    raise VVMVyperError(
+        stderr_data=modified_stderr,
+        stdout_data=error.stdout_data,
+        return_code=error.return_code,
+        command=error.command,
+    )

--- a/moccasin/_error_utils.py
+++ b/moccasin/_error_utils.py
@@ -1,19 +1,17 @@
 import re
-
 from pathlib import Path
+
 from vvm.exceptions import VyperError as VVMVyperError
 
-def handle_vvm_error(
-    error: VVMVyperError,
-    contract_path: Path,
-) -> None:
+
+def handle_vvm_error(error: VVMVyperError, contract_path: Path) -> None:
     """Handle VVM errors by adapting the error message and raising the exception.
     @param error: The VVMVyperError instance to handle.
     @param contract_path: The path to the contract file.
     @raises VVMVyperError: Raises a modified VVMVyperError with the updated error message.
     """
     original_stderr = error.stderr_data
-    temporary_path_pattern = r'contract "/tmp/vyper-[a-zA-Z0-9]+\.vy:(\d+)"'
+    temporary_path_pattern = r'contract "/tmp/vyper-[a-zA-Z0-9_-]+\.vy:(\d+)"'
     replacement_string = f'contract "{str(contract_path)}:\\1"'
 
     # Replace the temporary path with the actual contract path

--- a/moccasin/commands/compile.py
+++ b/moccasin/commands/compile.py
@@ -29,7 +29,6 @@ from moccasin.constants.vars import (
 from moccasin.logging import logger, set_log_level
 
 
-
 def main(args: Namespace) -> int:
     config = initialize_global_config()
     project_path: Path = config.get_root()

--- a/moccasin/commands/install.py
+++ b/moccasin/commands/install.py
@@ -61,9 +61,16 @@ def mox_install(
         config = get_or_initialize_config()
     if len(requirements) == 0:
         requirements = config.get_dependencies()
+
+    # Get dependencies install path and create it if it doesn't exist
+    # @dev allows to avoid vyper compiler error when missing one dir
+    install_path: Path = config.get_base_dependencies_install_path()
+    install_path.joinpath(PYPI).mkdir(exist_ok=True, parents=True)
+    install_path.joinpath(GITHUB).mkdir(exist_ok=True, parents=True)
     if len(requirements) == 0:
         logger.info("No dependencies to install.")
         return 0
+
     pip_requirements = []
     github_requirements = []
     for requirement in requirements:
@@ -71,12 +78,6 @@ def mox_install(
             github_requirements.append(requirement)
         else:
             pip_requirements.append(requirement)
-
-    # Get dependencies install path and create it if it doesn't exist
-    # @dev allows to avoid vyper compiler error when missing one dir
-    install_path: Path = config.get_base_dependencies_install_path()
-    install_path.joinpath(PYPI).mkdir(exist_ok=True, parents=True)
-    install_path.joinpath(GITHUB).mkdir(exist_ok=True, parents=True)
 
     # @dev in case of fresh install, dependencies might be ordered differently
     # since we install pip packages first and github packages later

--- a/tests/cli/test_cli_compile.py
+++ b/tests/cli/test_cli_compile.py
@@ -2,7 +2,7 @@ import os
 import subprocess
 from pathlib import Path
 
-from tests.constants import LIB_GH_PATH, LIB_PIP_PATH
+from tests.constants import LIB_GH_PATH, LIB_PIP_PATH, VVM_ERROR_PROJECT_PATH
 
 EXPECTED_HELP_TEXT = "Vyper compiler"
 
@@ -11,9 +11,9 @@ def test_compile_help(mox_path):
     result = subprocess.run(
         [mox_path, "compile", "-h"], check=True, capture_output=True, text=True
     )
-    assert (
-        EXPECTED_HELP_TEXT in result.stdout
-    ), "Help output does not contain expected text"
+    assert EXPECTED_HELP_TEXT in result.stdout, (
+        "Help output does not contain expected text"
+    )
     assert result.returncode == 0
 
 
@@ -21,9 +21,9 @@ def test_build_help(mox_path):
     result = subprocess.run(
         [mox_path, "build", "-h"], check=True, capture_output=True, text=True
     )
-    assert (
-        EXPECTED_HELP_TEXT in result.stdout
-    ), "Help output does not contain expected text"
+    assert EXPECTED_HELP_TEXT in result.stdout, (
+        "Help output does not contain expected text"
+    )
     assert result.returncode == 0
 
 
@@ -77,3 +77,63 @@ def test_compile_one(complex_temp_path, complex_cleanup_out_folder, mox_path):
     assert not complex_temp_path.joinpath(LIB_PIP_PATH).exists()
     assert "Done compiling BuyMeACoffee" in result.stderr
     assert result.returncode == 0
+
+
+def test_compile_with_vvm_assign_error(
+    mox_path, vvm_error_cleanup_out_folder, vvm_error_cleanup_dependencies_folder
+):
+    current_dir = Path.cwd()
+    try:
+        os.chdir(current_dir.joinpath(VVM_ERROR_PROJECT_PATH))
+        subprocess.run(
+            [mox_path, "build", "AssignError.vy"],
+            check=True,
+            capture_output=False,
+            text=True,
+        )
+    except subprocess.CalledProcessError as result:
+        assert "vvm.exceptions.VyperError" in result.stderr
+        assert "vyper.exceptions.StructureException" in result.stderr
+        assert f"{VVM_ERROR_PROJECT_PATH}/src/AssignError.vy:7" in result.stderr
+    finally:
+        os.chdir(current_dir)
+
+
+def test_compile_with_vvm_argument_error(
+    mox_path, vvm_error_cleanup_out_folder, vvm_error_cleanup_dependencies_folder
+):
+    current_dir = Path.cwd()
+    try:
+        os.chdir(current_dir.joinpath(VVM_ERROR_PROJECT_PATH))
+        subprocess.run(
+            [mox_path, "build", "ArgumentError.vy"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except subprocess.CalledProcessError as result:
+        assert "vvm.exceptions.VyperError" in result.stderr
+        assert "vyper.exceptions.ArgumentException" in result.stderr
+        assert f"{VVM_ERROR_PROJECT_PATH}/src/ArgumentError.vy:10" in result.stderr
+    finally:
+        os.chdir(current_dir)
+
+
+def test_compile_with_vvm_type_mismatch_error(
+    mox_path, vvm_error_cleanup_out_folder, vvm_error_cleanup_dependencies_folder
+):
+    current_dir = Path.cwd()
+    try:
+        os.chdir(current_dir.joinpath(VVM_ERROR_PROJECT_PATH))
+        subprocess.run(
+            [mox_path, "build", "TypeMismatchError.vy"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except subprocess.CalledProcessError as result:
+        assert "vvm.exceptions.VyperError" in result.stderr
+        assert "vyper.exceptions.TypeMismatch" in result.stderr
+        assert f"{VVM_ERROR_PROJECT_PATH}/src/TypeMismatchError.vy:7" in result.stderr
+    finally:
+        os.chdir(current_dir)

--- a/tests/cli/test_cli_compile.py
+++ b/tests/cli/test_cli_compile.py
@@ -88,7 +88,7 @@ def test_compile_with_vvm_assign_error(
         subprocess.run(
             [mox_path, "build", "AssignError.vy"],
             check=True,
-            capture_output=False,
+            capture_output=True,
             text=True,
         )
     except subprocess.CalledProcessError as result:

--- a/tests/cli/test_cli_install.py
+++ b/tests/cli/test_cli_install.py
@@ -35,5 +35,7 @@ def test_run_install_no_dependencies(
     assert "No dependencies to install" in result.stderr
 
     assert installation_temp_path.joinpath(MOCCASIN_TOML).exists()
-    assert not installation_temp_path.joinpath(LIB_GH_PATH).exists()
-    assert not installation_temp_path.joinpath(LIB_PIP_PATH).exists()
+    gh_path = installation_temp_path.joinpath(LIB_GH_PATH)
+    pip_path = installation_temp_path.joinpath(LIB_PIP_PATH)
+    assert gh_path.exists() and not os.listdir(gh_path)
+    assert pip_path.exists() and not os.listdir(pip_path)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,6 +28,7 @@ from tests.constants import (
     PURGE_PROJECT_PATH,
     PURGE_STARTING_TOML,
     TESTS_CONFIG_PROJECT_PATH,
+    VVM_ERROR_PROJECT_PATH,
 )
 from tests.utils.anvil import ANVIL_URL, AnvilProcess
 
@@ -274,6 +275,55 @@ def test_config_config(test_config_temp_path) -> Config:
     if os.path.exists(test_db_path):
         os.remove(test_db_path)
     return _set_global_config(test_config_temp_path)
+
+
+################################################################
+#                        TEST VVM ERROR                        #
+################################################################
+# @pytest.fixture(scope="module")
+# def vvm_error_temp_path() -> Generator[Path, None, None]:
+#     """Fixture to create a temporary directory for VVM error testing."""
+#     with tempfile.TemporaryDirectory() as temp_dir:
+#         shutil.copytree(
+#             VVM_ERROR_PROJECT_PATH, os.path.join(temp_dir), dirs_exist_ok=True
+#         )
+#         yield Path(temp_dir)
+
+
+@pytest.fixture(scope="module")
+def vvm_error_project_config() -> Config:
+    """Fixture to create a VVM error project mox configuration."""
+    test_db_path = os.path.join(VVM_ERROR_PROJECT_PATH, ".deployments.db")
+
+    if os.path.exists(test_db_path):
+        os.remove(test_db_path)
+
+    config = _set_global_config(VVM_ERROR_PROJECT_PATH)
+    return config
+
+
+@pytest.fixture(scope="module")
+def vvm_error_out_folder(vvm_error_project_config) -> Config:
+    """Fixture to get the output folder for VVM error testing."""
+    return vvm_error_project_config.out_folder
+
+
+@pytest.fixture
+def vvm_error_cleanup_out_folder(vvm_error_out_folder):
+    """Fixture to clean up the output folder after VVM error testing."""
+    yield
+    created_folder_path = VVM_ERROR_PROJECT_PATH.joinpath(vvm_error_out_folder)
+    if os.path.exists(created_folder_path):
+        shutil.rmtree(created_folder_path)
+
+
+@pytest.fixture
+def vvm_error_cleanup_dependencies_folder():
+    """Fixture to clean up the dependencies folder after VVM error testing."""
+    yield
+    created_folder_path = VVM_ERROR_PROJECT_PATH.joinpath(DEPENDENCIES_FOLDER)
+    if os.path.exists(created_folder_path):
+        shutil.rmtree(created_folder_path)
 
 
 # ------------------------------------------------------------------

--- a/tests/constants.py
+++ b/tests/constants.py
@@ -9,6 +9,7 @@ INSTALL_PROJECT_PATH = Path(__file__).parent.joinpath("data/installation_project
 NO_CONFIG_PROJECT_PATH = Path(__file__).parent.joinpath("data/no_config_project/")
 PURGE_PROJECT_PATH = Path(__file__).parent.joinpath("data/purge_project/")
 TESTS_CONFIG_PROJECT_PATH = Path(__file__).parent.joinpath("data/tests_project/")
+VVM_ERROR_PROJECT_PATH = Path(__file__).parent.joinpath("data/vvm_error_project/")
 ZKSYNC_PROJECT_PATH = Path(__file__).parent.joinpath("data/zksync_project/")
 
 # ------------------------------------------------------------------
@@ -71,7 +72,7 @@ save_to_db = false
 
 INSTALLATION_WITH_GH_TOML = """[project]
 dependencies = [
-    "PatrickAlphaC/test_repo@0.1.1",
+    "PatrickAlphaC/test_repo",
     "pcaversaccio/snekmate",
 ]
 
@@ -87,7 +88,7 @@ INSTALLATION_FULL_DEPENDENCIES_TOML = """[project]
 dependencies = [
     "snekmate", 
     "moccasin",
-    "PatrickAlphaC/test_repo@0.1.1",
+    "PatrickAlphaC/test_repo",
     "pcaversaccio/snekmate",
 ]
 
@@ -118,7 +119,7 @@ COMMENT_CONTENT = "PRESERVE COMMENTS"
 PACKAGE_NEW_VERSION = "0.0.5"
 ORG_NAME = "pcaversaccio"
 PIP_PACKAGE_NAME = "snekmate"
-PACKAGE_VERSION = "0.1.0"
+PACKAGE_VERSION = "0.1.1"
 GITHUB_PACKAGE_NAME = f"{ORG_NAME}/{PIP_PACKAGE_NAME}"
 LIB_GH_PATH = "lib/github"
 LIB_PIP_PATH = "lib/pypi"

--- a/tests/data/vvm_error_project/.coveragerc
+++ b/tests/data/vvm_error_project/.coveragerc
@@ -1,0 +1,2 @@
+[run]
+plugins = boa.coverage

--- a/tests/data/vvm_error_project/.gitattributes
+++ b/tests/data/vvm_error_project/.gitattributes
@@ -1,0 +1,3 @@
+
+*.sol linguist-language=Solidity
+*.vy linguist-language=Python

--- a/tests/data/vvm_error_project/.gitignore
+++ b/tests/data/vvm_error_project/.gitignore
@@ -1,0 +1,181 @@
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/latest/usage/project/#working-with-version-control
+.pdm.toml
+.pdm-python
+.pdm-build/
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/
+
+# Ruff / Rye
+.ruff_cache
+
+# Moccasin
+.env
+.env.unsafe
+.env*
+out/
+build/
+lib/
+.password.unsafe
+.password
+.password*
+.deployments*
+.deployments.db
+era_test_node.log
+anvil-zksync.log

--- a/tests/data/vvm_error_project/.vscode/settings.json
+++ b/tests/data/vvm_error_project/.vscode/settings.json
@@ -1,0 +1,9 @@
+{
+    "files.exclude": {
+        "**/__pycache__": true
+    },
+    "files.associations": {
+        ".coveragerc": "toml"
+    },
+    "vyper.command": "vyper -p ./lib/github -p ./lib/pypi"
+}

--- a/tests/data/vvm_error_project/README.md
+++ b/tests/data/vvm_error_project/README.md
@@ -1,0 +1,12 @@
+# Moccasin Project
+
+🐍 Welcome to your Moccasin project!
+
+## Quickstart
+
+```bash
+mox init
+mox run deploy
+```
+
+_For documentation, please run `mox --help` or visit [the Moccasin documentation](https://cyfrin.github.io/moccasin)_

--- a/tests/data/vvm_error_project/moccasin.toml
+++ b/tests/data/vvm_error_project/moccasin.toml
@@ -1,0 +1,25 @@
+[project]
+src = "src"
+out = "out"
+dot_env = ".env"
+
+[networks.pyevm]
+is_zksync = false
+
+[networks.anvil]
+url = "http://127.0.0.1:8545"
+prompt_live = false
+save_to_db = false
+chain_id = 31337
+
+[networks.sepolia]
+url = "https://ethereum-sepolia-rpc.publicnode.com"
+chain_id = 11155111
+
+[networks.zksync-sepolia]
+url = "https://sepolia.era.zksync.dev"
+chain_id = 300
+is_zksync = true
+prompt_live = true
+
+# You can view all configuration options at https://cyfrin.github.io/moccasin/all_moccasin_toml_parameters.html

--- a/tests/data/vvm_error_project/pyproject.toml
+++ b/tests/data/vvm_error_project/pyproject.toml
@@ -1,0 +1,7 @@
+[project]
+name = "moccasin_project"
+version = "0.1.0"
+description = "Add your description here"
+readme = "README.md"
+requires-python = ">=3.11"
+dependencies = []

--- a/tests/data/vvm_error_project/src/ArgumentError.vy
+++ b/tests/data/vvm_error_project/src/ArgumentError.vy
@@ -1,0 +1,12 @@
+# pragma version 0.4.0
+
+event TestEvent:
+    value: uint256
+    error: bool
+    error_code: uint256
+
+@external
+def test_event():
+    log TestEvent(value=1, error=True, error_code=2)
+    log TestEvent(value=1, error=False) # @dev instanciation error
+    log TestEvent(value=1, error=True, error_code=3)

--- a/tests/data/vvm_error_project/src/AssignError.vy
+++ b/tests/data/vvm_error_project/src/AssignError.vy
@@ -1,0 +1,15 @@
+# pragma version 0.4.0
+
+number: public(uint256)
+
+@external
+def set_number(new_number: uint256):
+    Hello
+    self.number = new_number
+
+@external
+def increment():
+    self.number += 1
+
+
+

--- a/tests/data/vvm_error_project/src/TypeMismatchError.vy
+++ b/tests/data/vvm_error_project/src/TypeMismatchError.vy
@@ -1,0 +1,10 @@
+# pragma version 0.4.0
+
+number: public(uint256)
+
+@external
+def set_number(new_number: String[10]):
+    self.number = new_number
+
+
+

--- a/tests/integration/test_integration_compile.py
+++ b/tests/integration/test_integration_compile.py
@@ -40,7 +40,7 @@ EXPECTED_HELP_TEXT = "Vyper compiler"
             True,
             [f"{PIP_PACKAGE_NAME}>={PACKAGE_VERSION}", f"{MOCCASIN_LIB_NAME}==0.3.6"],
             ["PatrickAlphaC/test_repo"],
-            {"patrickalphac/test_repo": "0.1.1"},
+            {"patrickalphac/test_repo": "0.1.2"},
         ),
         # Change compiled file
         (["MyTokenPyPI.vy"], [], True, ["snekmate==0.1.1"], [], None),

--- a/tests/integration/test_integration_deploy.py
+++ b/tests/integration/test_integration_deploy.py
@@ -38,7 +38,7 @@ from tests.utils.helpers import (
             True,
             [f"{PIP_PACKAGE_NAME}>={PACKAGE_VERSION}", f"{MOCCASIN_LIB_NAME}==0.3.6"],
             ["PatrickAlphaC/test_repo"],
-            {"patrickalphac/test_repo": "0.1.1"},
+            {"patrickalphac/test_repo": "0.1.2"},
         ),
         # Change compiled file
         (["price_feed"], [], True, ["snekmate==0.1.1"], [], None),

--- a/tests/integration/test_integration_install.py
+++ b/tests/integration/test_integration_install.py
@@ -346,7 +346,7 @@ def test_run_install_update_pip_and_gh(
         (
             [],
             ["snekmate", "moccasin", "PatrickAlphaC/test_repo"],
-            {"patrickalphac/test_repo": "0.1.1"},
+            {"patrickalphac/test_repo": "0.1.2"},
         ),
         # Change pip specification
         (
@@ -356,7 +356,7 @@ def test_run_install_update_pip_and_gh(
                 f"{PIP_PACKAGE_NAME}>={PACKAGE_VERSION}",
                 f"{MOCCASIN_LIB_NAME}==0.3.6",
             ],
-            {"patrickalphac/test_repo": "0.1.1"},
+            {"patrickalphac/test_repo": "0.1.2"},
         ),
         # Change gh specification
         (

--- a/tests/unit/test_unit_vvm_error.py
+++ b/tests/unit/test_unit_vvm_error.py
@@ -1,0 +1,56 @@
+from moccasin._error_utils import handle_vvm_error
+from pathlib import Path
+from unittest import mock
+from vvm.exceptions import VyperError as VVMVyperError
+
+
+def test_handle_vvm_error_with_different_temp_dirs():
+    """Tests the handle_vvm_error function with various temporary directory paths."""
+    contract_path = Path("src/AssignError.vy")
+
+    # Simulate different temporary directory paths
+    temp_dirs = [
+        "/tmp",
+        "/var/folders/some/random/T",
+        "/var/folders/h6/j1dkww4j5k9bvjpqtkyqcp3r0000gn/T",
+        "C:\\Users\\User\\AppData\\Local\\Temp",
+        "/private/tmp",
+        "C:\\TEMP",
+        "C:\\tmp",
+        "/usr/tmp",
+    ]
+
+    for temp_dir in temp_dirs:
+        with mock.patch("tempfile.gettempdir", return_value=temp_dir):
+            # Simulate the error message as it would appear in the VVMVyperError
+            simulated_stderr = (
+                f'contract "{temp_dir}/vyper-abcdef123456.vy:12": some error message'
+            )
+            simulated_command = [temp_dir, "vyper", str(contract_path)]
+            simulated_stdout = f"Error compiling: {temp_dir}/vyper-abcdef123456.vy"
+
+            original_error = VVMVyperError(
+                message="vvm.exceptions.VyperError: An error occurred during execution",
+                stderr_data=simulated_stderr,
+                stdout_data=simulated_stdout,
+                return_code=1,
+                command=simulated_command,
+            )
+
+            # Call the function to handle the error
+            try:
+                handle_vvm_error(original_error, contract_path)
+            except VVMVyperError as excinfo:
+                print(temp_dir)
+                # Check that the error message was modified correctly
+                assert str(contract_path) in excinfo.stderr_data
+                assert (
+                    f'contract "{str(contract_path)}:12": some error message'
+                    in excinfo.stderr_data
+                )
+                # Check that the command was modified correctly in stderr_data and not in stdout_data
+                assert (
+                    f"Error compiling: {temp_dir}/vyper-abcdef123456.vy"
+                    in excinfo.stdout_data
+                )
+                assert temp_dir not in excinfo.stderr_data


### PR DESCRIPTION
Related issue: #170 

Address temporary path issues in the VVM compiler. 

WIP since the problem could be in other CLI commands. Proposal to accept @PatrickAlphaC. Maybe we need to find a way to make it global and avoid duplication.

### Error handling enhancements:

* Added handling for `VVMVyperError` in the `compile` function. This includes a workaround to replace temporary paths in the error message with the actual contract path, improving the clarity of error logs.

### Import updates:

* Added `re` module import to facilitate regular expression operations for the error-handling logic.
* Imported `VyperError` as `VVMVyperError` from `vvm.exceptions` to handle VVM-specific errors.

