### PR TITLE
feat: add keystore location option to wallet cmd

### DIFF
--- a/docs/source/core_concepts/wallet.rst
+++ b/docs/source/core_concepts/wallet.rst
@@ -7,18 +7,20 @@ By default, you don't want to ever expose your private key in your scripts. You 
 
     mox wallet --help
 
-    usage: Moccasin CLI wallet [-h] [-d] [-q] {list,ls,generate,g,new,import,i,add,view,decrypt,dk,delete,d} ...
+    usage: Moccasin CLI wallet [-h] [-d] [-q] {list,ls,generate,g,new,import,i,add,view,decrypt,dk,delete,d,keystore-location,ks} ...
 
     Wallet management utilities.
 
     positional arguments:
-    {list,ls,generate,g,new,import,i,add,view,decrypt,dk,delete,d}
+    {list,ls,generate,g,new,import,i,add,view,decrypt,dk,delete,d,keystore-location,ks}
         list (ls)           List all the accounts in the keystore default directory
         generate (g, new)   Create a new account with a random private key
         import (i, add)     Import a private key into an encrypted keystore
         view                View the JSON of a keystore file
         decrypt (dk)        Decrypt a keystore file to get the private key
         delete (d)          Delete a keystore file
+        keystore-location (ks)
+                            Get the location of the keystore (e.g. related to your MOCCASIN_KEYSTORE_PATH)
 
     options:
     -h, --help            show this help message and exit

--- a/moccasin/__main__.py
+++ b/moccasin/__main__.py
@@ -445,6 +445,13 @@ Use this command to prepare your contracts for deployment or testing.""",
     )
     delete_parser.add_argument("keystore_file_name", help="Name of keystore file")
 
+    # Keystore location
+    wallet_subparsers.add_parser(
+        "keystore-location",
+        aliases=["ks"],
+        help="Get the location of the keystore (e.g. related to your MOCCASIN_KEYSTORE_PATH)",
+    )
+
     # ------------------------------------------------------------------
     #                        CONSOLE COMMAND
     # ------------------------------------------------------------------

--- a/moccasin/commands/wallet.py
+++ b/moccasin/commands/wallet.py
@@ -10,7 +10,7 @@ from eth_account.signers.local import LocalAccount
 from eth_account.types import PrivateKeyType
 from hexbytes import HexBytes
 
-from moccasin.constants.vars import MOCCASIN_KEYSTORE_PATH
+from moccasin.constants.vars import MOCCASIN_DEFAULT_FOLDER, MOCCASIN_KEYSTORE_PATH
 from moccasin.logging import logger
 
 ALIAS_TO_COMMAND = {"add": "import", "i": "import"}
@@ -43,6 +43,17 @@ def main(args: Namespace) -> int:
         )
         if key:
             logger.info("Rerun the command and use the '-p' flag to print it.")
+    elif wallet_command == "keystore-location":
+        # This command is used to check the location of the keystore
+        location_type = (
+            "default"
+            if MOCCASIN_KEYSTORE_PATH == MOCCASIN_DEFAULT_FOLDER.joinpath("keystores/")
+            else "custom"
+        )
+        # Log the location of the keystore
+        logger.info(
+            f"Keystore location: {MOCCASIN_KEYSTORE_PATH} ({location_type} location)"
+        )
     else:
         logger.error(f"Unknown accounts command: {wallet_command}")
         return 1

--- a/tests/cli/test_cli_wallet.py
+++ b/tests/cli/test_cli_wallet.py
@@ -15,3 +15,41 @@ def test_run_help(mox_path):
     finally:
         os.chdir(current_dir)
     assert "Moccasin CLI wallet" in result.stdout
+
+
+def test_run_keystore_location(mox_path, moccasin_home_folder):
+    current_dir = Path.cwd()
+    try:
+        os.chdir(COMPLEX_PROJECT_PATH)
+        result = subprocess.run(
+            [mox_path, "wallet", "keystore-location"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    finally:
+        os.chdir(current_dir)
+    # @dev using moccasin_home_folder fixture due to MOCCASIN_KEYSTORE_PATH
+    # being modified during session tests in temporary directory
+    assert (
+        f"Keystore location: {moccasin_home_folder.joinpath('keystores/')} (default location)"
+        in result.stderr
+    )
+
+
+def test_run_keystore_location_custom(mox_path, custom_moccasin_keystore_path):
+    current_dir = Path.cwd()
+    try:
+        os.chdir(COMPLEX_PROJECT_PATH)
+        result = subprocess.run(
+            [mox_path, "wallet", "keystore-location"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    finally:
+        os.chdir(current_dir)
+    assert (
+        f"Keystore location: {str(custom_moccasin_keystore_path)} (custom location)"
+        in result.stderr
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -80,6 +80,14 @@ def mox_path():
     return os.path.join(os.path.dirname(sys.executable), "mox")
 
 
+@pytest.fixture(scope="function")
+def custom_moccasin_keystore_path(session_monkeypatch, moccasin_home_folder):
+    """Set a custom keystore path for testing wallet `keystore-location`."""
+    custom_path = moccasin_home_folder.joinpath("custom_keystore")
+    session_monkeypatch.setenv("MOCCASIN_KEYSTORE_PATH", str(custom_path))
+    yield Path(custom_path)
+
+
 # ------------------------------------------------------------------
 #                    COMPLEX PROJECT FIXTURES
 # ------------------------------------------------------------------


### PR DESCRIPTION
# Related issue #151 

- Added `keystore-location` option to the `wallet` command to specify the keystore location.
- Update docs to reflect the new option.
- Updated tests to cover the new functionality.