### PR TITLE
Update setup-just to v3

### DIFF
--- a/.github/workflows/docs-release.yml
+++ b/.github/workflows/docs-release.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v6
       - name: Setup just
-        uses: extractions/setup-just@v2
+        uses: extractions/setup-just@v3
       - name: Sphinx build
         run: just docs
       - name: Deploy to GitHub Pages

--- a/.github/workflows/typecheck-and-formatting.yml
+++ b/.github/workflows/typecheck-and-formatting.yml
@@ -37,6 +37,6 @@ jobs:
     - name: Install dependencies
       run: uv sync --dev
     - name: Setup just
-      uses: extractions/setup-just@v2
+      uses: extractions/setup-just@v3
     - name: Run format
       run: just format-check

--- a/.github/workflows/typecheck-and-formatting.yml
+++ b/.github/workflows/typecheck-and-formatting.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Install dependencies
       run: uv sync --dev
     - name: Setup just
-      uses: extractions/setup-just@v2
+      uses: extractions/setup-just@v3
     - name: Run typecheck
       run: just typecheck
 


### PR DESCRIPTION
Using the latest v3 gives better compatibility, stability, and future-proofing.
Official v3 release is confirmed here → [setup-just@v3](https://github.com/extractions/setup-just/releases)