### PR TITLE
refactor: default installation of lib directory and adapt test env 

### DIFF
--- a/moccasin/commands/install.py
+++ b/moccasin/commands/install.py
@@ -61,9 +61,16 @@ def mox_install(
         config = get_or_initialize_config()
     if len(requirements) == 0:
         requirements = config.get_dependencies()
+
+    # Get dependencies install path and create it if it doesn't exist
+    # @dev allows to avoid vyper compiler error when missing one dir
+    install_path: Path = config.get_base_dependencies_install_path()
+    install_path.joinpath(PYPI).mkdir(exist_ok=True, parents=True)
+    install_path.joinpath(GITHUB).mkdir(exist_ok=True, parents=True)
     if len(requirements) == 0:
         logger.info("No dependencies to install.")
         return 0
+
     pip_requirements = []
     github_requirements = []
     for requirement in requirements:
@@ -71,12 +78,6 @@ def mox_install(
             github_requirements.append(requirement)
         else:
             pip_requirements.append(requirement)
-
-    # Get dependencies install path and create it if it doesn't exist
-    # @dev allows to avoid vyper compiler error when missing one dir
-    install_path: Path = config.get_base_dependencies_install_path()
-    install_path.joinpath(PYPI).mkdir(exist_ok=True, parents=True)
-    install_path.joinpath(GITHUB).mkdir(exist_ok=True, parents=True)
 
     # @dev in case of fresh install, dependencies might be ordered differently
     # since we install pip packages first and github packages later

--- a/tests/cli/test_cli_compile.py
+++ b/tests/cli/test_cli_compile.py
@@ -11,9 +11,9 @@ def test_compile_help(mox_path):
     result = subprocess.run(
         [mox_path, "compile", "-h"], check=True, capture_output=True, text=True
     )
-    assert (
-        EXPECTED_HELP_TEXT in result.stdout
-    ), "Help output does not contain expected text"
+    assert EXPECTED_HELP_TEXT in result.stdout, (
+        "Help output does not contain expected text"
+    )
     assert result.returncode == 0
 
 
@@ -21,9 +21,9 @@ def test_build_help(mox_path):
     result = subprocess.run(
         [mox_path, "build", "-h"], check=True, capture_output=True, text=True
     )
-    assert (
-        EXPECTED_HELP_TEXT in result.stdout
-    ), "Help output does not contain expected text"
+    assert EXPECTED_HELP_TEXT in result.stdout, (
+        "Help output does not contain expected text"
+    )
     assert result.returncode == 0
 
 

--- a/tests/cli/test_cli_install.py
+++ b/tests/cli/test_cli_install.py
@@ -35,5 +35,7 @@ def test_run_install_no_dependencies(
     assert "No dependencies to install" in result.stderr
 
     assert installation_temp_path.joinpath(MOCCASIN_TOML).exists()
-    assert not installation_temp_path.joinpath(LIB_GH_PATH).exists()
-    assert not installation_temp_path.joinpath(LIB_PIP_PATH).exists()
+    gh_path = installation_temp_path.joinpath(LIB_GH_PATH)
+    pip_path = installation_temp_path.joinpath(LIB_PIP_PATH)
+    assert gh_path.exists() and not os.listdir(gh_path)
+    assert pip_path.exists() and not os.listdir(pip_path)

--- a/tests/constants.py
+++ b/tests/constants.py
@@ -71,7 +71,7 @@ save_to_db = false
 
 INSTALLATION_WITH_GH_TOML = """[project]
 dependencies = [
-    "PatrickAlphaC/test_repo@0.1.1",
+    "PatrickAlphaC/test_repo",
     "pcaversaccio/snekmate",
 ]
 
@@ -87,7 +87,7 @@ INSTALLATION_FULL_DEPENDENCIES_TOML = """[project]
 dependencies = [
     "snekmate", 
     "moccasin",
-    "PatrickAlphaC/test_repo@0.1.1",
+    "PatrickAlphaC/test_repo",
     "pcaversaccio/snekmate",
 ]
 
@@ -118,7 +118,7 @@ COMMENT_CONTENT = "PRESERVE COMMENTS"
 PACKAGE_NEW_VERSION = "0.0.5"
 ORG_NAME = "pcaversaccio"
 PIP_PACKAGE_NAME = "snekmate"
-PACKAGE_VERSION = "0.1.0"
+PACKAGE_VERSION = "0.1.1"
 GITHUB_PACKAGE_NAME = f"{ORG_NAME}/{PIP_PACKAGE_NAME}"
 LIB_GH_PATH = "lib/github"
 LIB_PIP_PATH = "lib/pypi"

--- a/tests/integration/test_integration_compile.py
+++ b/tests/integration/test_integration_compile.py
@@ -40,7 +40,7 @@ EXPECTED_HELP_TEXT = "Vyper compiler"
             True,
             [f"{PIP_PACKAGE_NAME}>={PACKAGE_VERSION}", f"{MOCCASIN_LIB_NAME}==0.3.6"],
             ["PatrickAlphaC/test_repo"],
-            {"patrickalphac/test_repo": "0.1.1"},
+            {"patrickalphac/test_repo": "0.1.2"},
         ),
         # Change compiled file
         (["MyTokenPyPI.vy"], [], True, ["snekmate==0.1.1"], [], None),

--- a/tests/integration/test_integration_deploy.py
+++ b/tests/integration/test_integration_deploy.py
@@ -38,7 +38,7 @@ from tests.utils.helpers import (
             True,
             [f"{PIP_PACKAGE_NAME}>={PACKAGE_VERSION}", f"{MOCCASIN_LIB_NAME}==0.3.6"],
             ["PatrickAlphaC/test_repo"],
-            {"patrickalphac/test_repo": "0.1.1"},
+            {"patrickalphac/test_repo": "0.1.2"},
         ),
         # Change compiled file
         (["price_feed"], [], True, ["snekmate==0.1.1"], [], None),

--- a/tests/integration/test_integration_install.py
+++ b/tests/integration/test_integration_install.py
@@ -346,7 +346,7 @@ def test_run_install_update_pip_and_gh(
         (
             [],
             ["snekmate", "moccasin", "PatrickAlphaC/test_repo"],
-            {"patrickalphac/test_repo": "0.1.1"},
+            {"patrickalphac/test_repo": "0.1.2"},
         ),
         # Change pip specification
         (
@@ -356,7 +356,7 @@ def test_run_install_update_pip_and_gh(
                 f"{PIP_PACKAGE_NAME}>={PACKAGE_VERSION}",
                 f"{MOCCASIN_LIB_NAME}==0.3.6",
             ],
-            {"patrickalphac/test_repo": "0.1.1"},
+            {"patrickalphac/test_repo": "0.1.2"},
         ),
         # Change gh specification
         (


### PR DESCRIPTION
Changes added in #236, but since it is a complex feature, I exported the unrelated changes in a different refactor branch.
It will ease the review and allow for non-blocking features to pass while working on the complexity.

---

- Fix default library directory installation to actually work as expected.
- Adapt tests to reflect the new default library directory installation.
- Update constants related to package versions.