### PR TITLE
fix: broken link for fuzzing in doc

### DIFF
--- a/docs/source/core_concepts/testing/coverage.rst
+++ b/docs/source/core_concepts/testing/coverage.rst
@@ -1,10 +1,10 @@
 Coverage
 ########
 
-.. note:: See the `titanoboa gas-profiling documentation for more information. <https://titanoboa.readthedocs.io/en/latest/testing.html#coverage>`_
+.. note:: See the `titanoboa computing test coverage documentation for more information. <https://titanoboa.readthedocs.io/en/latest/guides/testing/coverage/>`_
 
 
-You can also run coverage tests, using the ``--coverage`` flag, and any flag the comes with `pytest-cov <https://pypi.org/project/pytest-cov/>`_. This also uses `titanoboa <https://titanoboa.readthedocs.io/en/latest/testing.html#coverage>`_ under the hood. 
+You can also run coverage tests, using the ``--coverage`` flag, and any flag the comes with `pytest-cov <https://pypi.org/project/pytest-cov/>`_. This also uses `titanoboa <https://titanoboa.readthedocs.io/en/latest/guides/testing/coverage/>`_ under the hood. 
 
 To run coverage tests, you can run:
 

--- a/docs/source/core_concepts/testing/fuzzing.rst
+++ b/docs/source/core_concepts/testing/fuzzing.rst
@@ -5,8 +5,8 @@ In ``moccasin``, we use `hypothesis <https://hypothesis.readthedocs.io/en/latest
 
 If you'd like to see how to do fuzzing in ``moccasin``, head over to either:
 
-- `Stateless Fuzzing <how-tos/stateless_fuzzing.rst>`_
-- `Stateful Fuzzing <how-tos/stateful_fuzzing.rst>`_
+- :doc:`Stateless Fuzzing </how-tos/stateless_fuzzing>`
+- :doc:`Stateful Fuzzing </how-tos/stateful_fuzzing>`
 
 What is fuzzing?
 ================
@@ -154,5 +154,5 @@ You can learn more about fuzzing from the video here:
 And then, learn how to do stateless and stateful fuzz tests in ``moccasin`` from these guides.
 
 
-- `Stateless Fuzzing <how-tos/stateless_fuzzing.rst>`_
-- `Stateful Fuzzing <how-tos/stateful_fuzzing.rst>`_
+- :doc:`Stateless Fuzzing </how-tos/stateless_fuzzing>`
+- :doc:`Stateful Fuzzing </how-tos/stateful_fuzzing>`

--- a/docs/source/core_concepts/testing/gas_profiling.rst
+++ b/docs/source/core_concepts/testing/gas_profiling.rst
@@ -1,9 +1,9 @@
 Gas Profiling
 #############
 
-.. note:: See the `titanoboa gas-profiling documentation for more information. <https://titanoboa.readthedocs.io/en/latest/testing.html#gas-profiling>`_
+.. note:: See the `titanoboa gas profiling documentation for more information. <https://titanoboa.readthedocs.io/en/latest/guides/testing/gas_profiling/>`_
 
-``moccasin`` has a built in gas profiler that can be used to profile your contracts gas usage. It uses `titanoboa's <https://titanoboa.readthedocs.io/en/latest/testing.html#gas-profiling>`_ gas profiling under the hood. 
+``moccasin`` has a built in gas profiler that can be used to profile your contracts gas usage. It uses `titanoboa's <https://titanoboa.readthedocs.io/en/latest/guides/testing/gas_profiling/>`_ gas profiling under the hood. 
 
 To use the gas profiler, you can run:
 

--- a/docs/source/core_concepts/testing/titanoboa_testing.rst
+++ b/docs/source/core_concepts/testing/titanoboa_testing.rst
@@ -3,6 +3,6 @@ Titanoboa Testing
 
 Because ``moccasin`` uses ``titanoboa`` under the hood, you can use all the same testing features that ``titanoboa`` has, including:
 
-- `Fuzzing <https://titanoboa.readthedocs.io/en/latest/testing.html#fuzzing-strategies>`_ 
-- `Native import syntax <https://titanoboa.readthedocs.io/en/latest/testing.html#native-import-syntax>`_ 
-- `And more <https://titanoboa.readthedocs.io/en/latest/api.html>`_
+- `Fuzzing <https://titanoboa.readthedocs.io/en/latest/guides/testing/fuzzing_strategies/#fuzzing-strategies>`_ 
+- `Native import syntax <https://titanoboa.readthedocs.io/en/latest/guides/scripting/native_import_syntax/>`_ 
+- `And more <https://titanoboa.readthedocs.io/en/latest/>`_


### PR DESCRIPTION
In `docs/source/core_concepts/testing/fuzzing.rst`, replace plain hyperlink syntax with reStructuredText's `:doc:` directive for better integration with Sphinx documentation tools.

Documentation improvements:

* Updated links to `Stateless Fuzzing` and `Stateful Fuzzing` guides to use the `:doc:` directive for improved Sphinx compatibility. [[1]](diffhunk://#diff-5e2b66c0385958b21cb9a813a2b3a1bc905e68c5928820e36d3e77d4264704feL8-R9) [[2]](diffhunk://#diff-5e2b66c0385958b21cb9a813a2b3a1bc905e68c5928820e36d3e77d4264704feL157-R158)