### PR TITLE
feat: add vyper to mox CLI

### DIFF
--- a/moccasin/__main__.py
+++ b/moccasin/__main__.py
@@ -46,6 +46,18 @@ def main(argv: list) -> int:
         except Exception as e:
             logger.error(f"Error parsing Vyper command: {e}")
             return 1
+
+    # Special case for format command - pass all args through to mamushi
+    if len(argv) > 0 and argv[0] == "format":
+        try:
+            args = argparse.Namespace()
+            args.command = "format"
+            args.format_args = argv[1:]  # Pass all remaining args to mamushi
+            logger.info("Running format command...")
+            return import_module("moccasin.commands.format").main(args)
+        except Exception as e:
+            logger.error(f"Error running format command: {e}")
+            return 1
     
     main_parser, sub_parsers = generate_main_parser_and_sub_parsers()
 

--- a/moccasin/commands/format.py
+++ b/moccasin/commands/format.py
@@ -1,0 +1,45 @@
+import subprocess
+from argparse import Namespace
+
+from moccasin.config import get_config, initialize_global_config
+from moccasin.logging import logger
+
+
+def main(args: Namespace) -> int:
+    """Format Vyper source code using mamushi."""
+    initialize_global_config()
+    config = get_config()
+
+    # Get the format args passed from the CLI
+    format_args = getattr(args, "format_args", [])
+
+    # If no files specified in args, add all .vy files from src folder
+    files_in_args = [arg for arg in format_args if not arg.startswith("-")]
+    if not files_in_args:
+        src_folder = config.project_root / config.src_folder
+        if src_folder.exists():
+            vy_files = list(src_folder.glob("**/*.vy"))
+            if vy_files:
+                format_args.extend([str(f) for f in vy_files])
+
+        if not format_args:
+            logger.error("No Vyper files found to format.")
+            logger.info(
+                f"Make sure you have .vy files in your {src_folder} directory or specify files explicitly."
+            )
+            return 1
+
+    cmd = ["mamushi"] + format_args
+
+    logger.debug(f"Running mamushi command: {' '.join(cmd)}")
+
+    try:
+        result = subprocess.run(cmd, check=False)
+        return result.returncode
+    except FileNotFoundError:
+        logger.error("mamushi formatter not found.")
+        logger.error("Install it with: uv tool install mamushi")
+        return 1
+    except Exception as e:
+        logger.error(f"Error running mamushi command: {e}")
+        return 1

--- a/moccasin/commands/vyper.py
+++ b/moccasin/commands/vyper.py
@@ -2,7 +2,6 @@ import os
 import subprocess
 import sys
 from argparse import Namespace
-from pathlib import Path
 
 from moccasin._sys_path_and_config_setup import _patch_sys_path, get_sys_paths_list
 from moccasin.commands.install import mox_install
@@ -12,13 +11,13 @@ from moccasin.logging import logger
 
 def main(args: Namespace) -> int:
     config = initialize_global_config()
-    
+
     if not args.no_install:
         mox_install(config=config, quiet=True, override_logger=True)
-    
+
     vyper_args = []
     i = 2  # Start after "mox vyper"
-    
+
     # Skip --no-install flag
     while i < len(sys.argv):
         arg = sys.argv[i]
@@ -34,22 +33,20 @@ def main(args: Namespace) -> int:
         return 1
 
     cmd = ["vyper"] + vyper_args
-    
+
     logger.debug(f"Running Vyper command: {' '.join(cmd)}")
-    
+
     # Run the command with patched sys.path for dependency resolution
     with _patch_sys_path(get_sys_paths_list(config)):
         env = os.environ.copy()
-        
+
         try:
-            result = subprocess.run(
-                cmd,
-                check=False,
-                env=env
-            )
+            result = subprocess.run(cmd, check=False, env=env)
             return result.returncode
         except FileNotFoundError:
-            logger.error("Vyper compiler not found. Make sure it's installed and in your PATH.")
+            logger.error(
+                "Vyper compiler not found. Install it with: uv tool install vyper"
+            )
             return 1
         except Exception as e:
             logger.error(f"Error running Vyper command: {e}")

--- a/moccasin/commands/vyper.py
+++ b/moccasin/commands/vyper.py
@@ -1,0 +1,56 @@
+import os
+import subprocess
+import sys
+from argparse import Namespace
+from pathlib import Path
+
+from moccasin._sys_path_and_config_setup import _patch_sys_path, get_sys_paths_list
+from moccasin.commands.install import mox_install
+from moccasin.config import initialize_global_config
+from moccasin.logging import logger
+
+
+def main(args: Namespace) -> int:
+    config = initialize_global_config()
+    
+    if not args.no_install:
+        mox_install(config=config, quiet=True, override_logger=True)
+    
+    vyper_args = []
+    i = 2  # Start after "mox vyper"
+    
+    # Skip --no-install flag
+    while i < len(sys.argv):
+        arg = sys.argv[i]
+        if arg == "--no-install":
+            i += 1
+            continue
+        vyper_args.append(arg)
+        i += 1
+
+    if not vyper_args:
+        logger.error("No arguments provided to pass to the Vyper compiler.")
+        logger.info("Example usage: mox vyper -f external_interface src/MyContract.vy")
+        return 1
+
+    cmd = ["vyper"] + vyper_args
+    
+    logger.debug(f"Running Vyper command: {' '.join(cmd)}")
+    
+    # Run the command with patched sys.path for dependency resolution
+    with _patch_sys_path(get_sys_paths_list(config)):
+        env = os.environ.copy()
+        
+        try:
+            result = subprocess.run(
+                cmd,
+                check=False,
+                env=env
+            )
+            return result.returncode
+        except FileNotFoundError:
+            logger.error("Vyper compiler not found. Make sure it's installed and in your PATH.")
+            return 1
+        except Exception as e:
+            logger.error(f"Error running Vyper command: {e}")
+            return 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,7 @@ dev-dependencies = [
     "vyper>=0.4.1",
     "ruff>=0.6.3",
     "moccasin",
+    "mamushi>=0.0.5",
 ]
 
 [project.urls]

--- a/tests/cli/test_cli_format.py
+++ b/tests/cli/test_cli_format.py
@@ -1,0 +1,13 @@
+import subprocess
+
+
+def test_format_help(mox_path):
+    """Test format command help output."""
+    result = subprocess.run(
+        [mox_path, "format", "--help"], capture_output=True, text=True
+    )
+    # Since format command passes args to mamushi, we expect mamushi help or error
+    assert result.returncode in [
+        0,
+        1,
+    ]  # Could be 0 (mamushi installed) or 1 (not installed)

--- a/tests/cli/test_cli_vyper.py
+++ b/tests/cli/test_cli_vyper.py
@@ -1,0 +1,65 @@
+import os
+import subprocess
+from pathlib import Path
+
+
+def test_vyper_help(mox_path):
+    """Test vyper command help output."""
+    result = subprocess.run(
+        [mox_path, "vyper", "--help"], check=True, capture_output=True, text=True
+    )
+    assert "usage: vyper" in result.stdout
+    assert result.returncode == 0
+
+
+def test_vyper_version(mox_path):
+    """Test vyper command version output."""
+    result = subprocess.run(
+        [mox_path, "vyper", "--version"], check=True, capture_output=True, text=True
+    )
+    assert result.returncode == 0
+
+
+def test_vyper_with_contract(complex_temp_path, mox_path):
+    """Test vyper command with a contract file."""
+    current_dir = Path.cwd()
+    try:
+        os.chdir(current_dir.joinpath(complex_temp_path))
+        result = subprocess.run(
+            [mox_path, "vyper", "-f", "abi", "contracts/Counter.vy", "--no-install"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    finally:
+        os.chdir(current_dir)
+
+    # Should contain ABI output
+    assert "[" in result.stdout  # JSON array start
+    assert result.returncode == 0
+
+
+def test_vyper_external_interface(complex_temp_path, mox_path):
+    """Test vyper command with external interface format."""
+    current_dir = Path.cwd()
+    try:
+        os.chdir(current_dir.joinpath(complex_temp_path))
+        result = subprocess.run(
+            [
+                mox_path,
+                "vyper",
+                "-f",
+                "external_interface",
+                "contracts/Counter.vy",
+                "--no-install",
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    finally:
+        os.chdir(current_dir)
+
+    # Should contain interface output
+    assert "interface" in result.stdout.lower()
+    assert result.returncode == 0

--- a/tests/data/complex_project/contracts/Auth.vy
+++ b/tests/data/complex_project/contracts/Auth.vy
@@ -3,12 +3,15 @@
 # Not export to importing module?
 owner: public(address)
 
+
 @deploy
 def __init__():
     self.owner = msg.sender
 
+
 def _check_owner():
     assert self.owner == msg.sender
+
 
 # Must be exported by importing module
 @external

--- a/tests/data/complex_project/contracts/BuyMeACoffee.vy
+++ b/tests/data/complex_project/contracts/BuyMeACoffee.vy
@@ -9,6 +9,7 @@
 """
 
 from interfaces import AggregatorV3Interface
+
 # interface AggregatorV3Interface:
 #     def decimals() -> uint8: view
 #     def description() -> String[1000]: view
@@ -25,6 +26,7 @@ some_value: public(decimal)
 funders: public(DynArray[address, 100])
 address_to_amount_funded: public(HashMap[address, uint256])
 price_feed: public(AggregatorV3Interface)
+
 
 @deploy
 def __init__(price_feed: address):

--- a/tests/data/complex_project/contracts/Counter.vy
+++ b/tests/data/complex_project/contracts/Counter.vy
@@ -4,9 +4,11 @@
 number: public(uint256)
 other_number: public(uint256)
 
+
 @external
 def set_number(new_number: uint256):
     self.number = new_number
+
 
 @external
 def increment():

--- a/tests/data/complex_project/contracts/InitializedAuth.vy
+++ b/tests/data/complex_project/contracts/InitializedAuth.vy
@@ -10,6 +10,7 @@ initializes: UninitializedAuth[auth := auth]
 # export all external functions
 exports: UninitializedAuth.__interface__
 
+
 @deploy
 def __init__():
     auth.__init__()

--- a/tests/data/complex_project/contracts/UninitializedAuth.vy
+++ b/tests/data/complex_project/contracts/UninitializedAuth.vy
@@ -8,14 +8,17 @@ uses: auth
 
 pending_owner: address
 
+
 @deploy
 def __init__():
     pass
+
 
 @external
 def begin_transfer(new_owner: address):
     auth._check_owner()
     self.pending_owner = new_owner
+
 
 @external
 def accept_transfer():

--- a/tests/data/complex_project/contracts/mocks/MockV3Aggregator.vy
+++ b/tests/data/complex_project/contracts/mocks/MockV3Aggregator.vy
@@ -15,22 +15,27 @@ decimals: uint256
 
 version: public(constant(uint256)) = 2
 
+
 @internal
 def updateAnswer(_answer: int256):
     self.latestAnswer = _answer
     self.latestTimestamp = block.timestamp
     self.latestRound = self.latestRound + 1
-    self.getAnswer[self.latestRound] = _answer 
+    self.getAnswer[self.latestRound] = _answer
     self.getTimestamp[self.latestRound] = block.timestamp
     self.getStartedAt[self.latestRound] = block.timestamp
+
 
 @deploy
 def __init__(_decimals: uint8, _initialAnswer: int256):
     DECIMALS = _decimals
     self.updateAnswer(_initialAnswer)
 
+
 @external
-def updateRoundData(_roundId: uint256, _answer: int256, _timestamp: uint256, _startedAt: uint256):
+def updateRoundData(
+    _roundId: uint256, _answer: int256, _timestamp: uint256, _startedAt: uint256
+):
     self.latestRound = _roundId
     self.latestAnswer = _answer
     self.latestTimestamp = _timestamp
@@ -38,13 +43,28 @@ def updateRoundData(_roundId: uint256, _answer: int256, _timestamp: uint256, _st
     self.getTimestamp[self.latestRound] = _timestamp
     self.getStartedAt[self.latestRound] = _startedAt
 
+
 @external
-@view 
-def getRoundData(_roundId: uint256) -> (uint256, int256, uint256, uint256, uint256): 
-    return (_roundId, self.getAnswer[_roundId], self.getStartedAt[_roundId], self.getTimestamp[_roundId], _roundId)
+@view
+def getRoundData(
+    _roundId: uint256,
+) -> (uint256, int256, uint256, uint256, uint256):
+    return (
+        _roundId,
+        self.getAnswer[_roundId],
+        self.getStartedAt[_roundId],
+        self.getTimestamp[_roundId],
+        _roundId,
+    )
 
 
 @external
-@view 
-def latestRoundData() -> (uint256, int256, uint256, uint256, uint256): 
-    return (self.latestRound, self.getAnswer[self.latestRound], self.getStartedAt[self.latestRound], self.getTimestamp[self.latestRound], self.latestRound)
+@view
+def latestRoundData() -> (uint256, int256, uint256, uint256, uint256):
+    return (
+        self.latestRound,
+        self.getAnswer[self.latestRound],
+        self.getStartedAt[self.latestRound],
+        self.getTimestamp[self.latestRound],
+        self.latestRound,
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -290,14 +290,14 @@ wheels = [
 
 [[package]]
 name = "click"
-version = "8.1.8"
+version = "8.1.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b9/2e/0090cbf739cee7d23781ad4b89a9894a41538e4fcf4c31dcdd705b78eb8b/click-8.1.8.tar.gz", hash = "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a", size = 226593, upload-time = "2024-12-21T18:38:44.339Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/59/87/84326af34517fca8c58418d148f2403df25303e02736832403587318e9e8/click-8.1.3.tar.gz", hash = "sha256:7682dc8afb30297001674575ea00d1814d808d6a36af415a82bd481d37ba7b8e", size = 331147, upload-time = "2022-04-28T17:36:09.097Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/d4/7ebdbd03970677812aac39c869717059dbb71a4cfc033ca6e5221787892c/click-8.1.8-py3-none-any.whl", hash = "sha256:63c132bbbed01578a06712a2d1f497bb62d9c1c0d329b7903a866228027263b2", size = 98188, upload-time = "2024-12-21T18:38:41.666Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/f1/df59e28c642d583f7dacffb1e0965d0e00b218e0186d7858ac5233dce840/click-8.1.3-py3-none-any.whl", hash = "sha256:bb4d8133cb15a609f44e8213d9b391b0809795062913b383c62be0ee95b1db48", size = 96588, upload-time = "2022-04-28T17:36:06.952Z" },
 ]
 
 [[package]]
@@ -841,6 +841,21 @@ wheels = [
 ]
 
 [[package]]
+name = "mamushi"
+version = "0.0.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "lark" },
+    { name = "mypy-extensions" },
+    { name = "pathspec" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d5/02/8ac3c0b8c5fdb925fd7ab5c7aecef2fed47f76ecea7276430963c37a052e/mamushi-0.0.5.tar.gz", hash = "sha256:0dd68c28aec1f2dc1c102fb3f71c82854ad80ae980e72dfad83cced76d1ece98", size = 45990, upload-time = "2025-05-31T06:11:35.849Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/59/f5/1f8c972a260d87580e81ac015a6a5a0a94c459312b4299bba6f767d0bd6f/mamushi-0.0.5-py3-none-any.whl", hash = "sha256:92f159b92e0f2661b3992f214c420e73519ad99e1e5e40f6a36ebbc86648d2b8", size = 48328, upload-time = "2025-05-31T06:11:34.302Z" },
+]
+
+[[package]]
 name = "markdown"
 version = "3.7"
 source = { registry = "https://pypi.org/simple" }
@@ -1039,6 +1054,7 @@ docs = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "mamushi" },
     { name = "moccasin" },
     { name = "mypy" },
     { name = "pytest" },
@@ -1072,6 +1088,7 @@ provides-extras = ["docs"]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "mamushi", specifier = ">=0.0.5" },
     { name = "moccasin", editable = "." },
     { name = "mypy", specifier = ">=1.11.0" },
     { name = "pytest", specifier = ">=8.3.2" },
@@ -1113,11 +1130,11 @@ wheels = [
 
 [[package]]
 name = "mypy-extensions"
-version = "1.0.0"
+version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/98/a4/1ab47638b92648243faf97a5aeb6ea83059cc3624972ab6b8d2316078d3f/mypy_extensions-1.0.0.tar.gz", hash = "sha256:75dbf8955dc00442a438fc4d0666508a9a97b6bd41aa2f0ffe9d2f2725af0782", size = 4433, upload-time = "2023-02-04T12:11:27.157Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2a/e2/5d3f6ada4297caebe1a2add3b126fe800c96f56dbe5d1988a2cbe0b267aa/mypy_extensions-1.0.0-py3-none-any.whl", hash = "sha256:4392f6c0eb8a5668a69e23d168ffa70f0be9ccfd32b5cc2d26a34ae5b844552d", size = 4695, upload-time = "2023-02-04T12:11:25.002Z" },
+    { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Add a `vyper` command to moccasin's CLI that allows to run vyper with moccasin's dependency resolution.

This allows to use the vyper formatting functions for interface or abi generation within a moccasin project that uses dependencies installed with moccasin.