### PR TITLE
docs: update common errors documentation

### DIFF
--- a/docs/source/common_errors.rst
+++ b/docs/source/common_errors.rst
@@ -1,15 +1,22 @@
 Common Errors
 =============
 
-ValueError: <boa.network.NetworkEnv object at 0xXXXXXXXXX>.eoa not defined!
-----------------------------------------------------------------------------
+----
+
+Value Error: Account Not Defined
+--------------------------------
+
+.. error:: ValueError: <boa.network.NetworkEnv object at 0xXXXXXXXXX>.eoa not defined!
 
 This is the most common error you'll encounter, and it means you'll need to add an account to your ``moccasin.toml`` file. You can do this by following the :doc:`wallet <core_concepts/wallet>` guide.
 
 ----
 
-FileNotFoundError: [Errno 2] No such file or directory: 'lib'
---------------------------------------------------------------
+File Not Found Error: Missing 'lib' Directory
+---------------------------------------------
+
+.. error:: FileNotFoundError: [Errno 2] No such file or directory: 'lib'
+
 This error occurs when Moccasin cannot find the `lib` directory in your project, or it is missing ``github`` and/or ``pypi`` directory. 
 To fix this, you can create the `lib` directory in your project root:
 
@@ -23,8 +30,10 @@ Or with recent versions of Moccasin, you can run ``mox install`` to automaticall
 
 ----
 
-VersionException: Version specification ``"==x.x.x"`` is not compatible with compiler version
--------------------------------------------------------------------------------------------------------------------
+VersionException: Compiler Incompatibility
+------------------------------------------
+
+.. error:: VersionException: Version specification ``"==x.x.x"`` is not compatible with compiler version
 
 This error usually occurs with VSCode and its `Vyper extension <https://marketplace.visualstudio.com/items?itemName=tintinweb.vscode-vyper>`_.
 By default, the extension will use your global Vyper installation, which may not match the version specified in your ``pyproject.toml`` file.
@@ -48,8 +57,10 @@ You can change it like this to get the vyper version from your project's virtual
 
 ----
 
-AssertionError: Bytecode length must be a multiple of 32 bytes (ZKsync)
-------------------------------------------------------------------------
+AssertionError: Bytecode Length (ZKsync)
+----------------------------------------
+
+.. error:: AssertionError: Bytecode length must be a multiple of 32 bytes (ZKsync)
 
 This error occurs when you try to deploy a contract on ZKsync and it might not be related to the feedback from the compiler.
 Usually, it is because ``moccasin`` installed with ``uv tool`` comes with its own dependencies installed by default to the latest version.
@@ -69,3 +80,22 @@ Check your ``pyproject.toml`` file for the required version of ``vyper``. For ex
 .. code-block:: toml
 
     dependencies = ["moccasin==0.4.0", "vyper==0.4.1"]
+
+----
+
+AssertionError: `create_copy_of` Not Supported
+----------------------------------------------
+
+.. error:: AssertionError: Built-in function ``create_copy_of`` is not supported
+
+This error occurs when you try to use the ``create_copy_of`` function in your Vyper code while using ZKsync as the network.
+``create_copy_of`` is forbidden in ``zkvyper``, which is the Vyper version used by ZKsync.
+To fix this, you can use another method called ``create_from_blueprint`` instead:
+
+.. code-block:: python
+
+    @external
+    def create_favorite_contract() -> address:
+        new_favorite_contract: address = create_from_blueprint(self.original_favorite_contract)
+        self.list_of_new_favorite_contract.append(new_favorite_contract)
+        return new_favorite_contract

--- a/docs/source/common_errors.rst
+++ b/docs/source/common_errors.rst
@@ -5,3 +5,67 @@ ValueError: <boa.network.NetworkEnv object at 0xXXXXXXXXX>.eoa not defined!
 ----------------------------------------------------------------------------
 
 This is the most common error you'll encounter, and it means you'll need to add an account to your ``moccasin.toml`` file. You can do this by following the :doc:`wallet <core_concepts/wallet>` guide.
+
+----
+
+FileNotFoundError: [Errno 2] No such file or directory: 'lib'
+--------------------------------------------------------------
+This error occurs when Moccasin cannot find the `lib` directory in your project, or it is missing ``github`` and/or ``pypi`` directory. 
+To fix this, you can create the `lib` directory in your project root:
+
+.. code-block:: bash
+
+    mkdir lib
+    mkdir lib/github
+    mkdir lib/pypi
+
+Or with recent versions of Moccasin, you can run ``mox install`` to automatically create the `lib` directory and its subdirectories.
+
+----
+
+VersionException: Version specification ``"==x.x.x"`` is not compatible with compiler version
+-------------------------------------------------------------------------------------------------------------------
+
+This error usually occurs with VSCode and its `Vyper extension <https://marketplace.visualstudio.com/items?itemName=tintinweb.vscode-vyper>`_.
+By default, the extension will use your global Vyper installation, which may not match the version specified in your ``pyproject.toml`` file.
+If you have initialized your project with ``mox init --vscode``, you can fix this by changing the following setting in your VSCode ``.vscode/settings.json`` file:
+
+.. code-block:: json
+
+    {
+        // ...
+        "vyper.command": "vyper -p ./lib/github -p ./lib/pypi"
+    }
+
+You can change it like this to get the vyper version from your project's virtual environment:
+
+.. code-block:: json
+
+    {
+        // ...
+        "vyper.command": "./.venv/bin/vyper -p ./lib/github -p ./lib/pypi"
+    }
+
+----
+
+AssertionError: Bytecode length must be a multiple of 32 bytes (ZKsync)
+------------------------------------------------------------------------
+
+This error occurs when you try to deploy a contract on ZKsync and it might not be related to the feedback from the compiler.
+Usually, it is because ``moccasin`` installed with ``uv tool`` comes with its own dependencies installed by default to the latest version.
+Therefore, if you use ``mox`` from the tool, it will try to deploy with its own ``vyper`` depedency. 
+
+To fix this, you need to add ``moccasin`` to your project's virtual environment and install the dependencies there.
+You can do this by running the following command in your project directory:
+
+.. code-block:: bash
+
+    uv add moccasin
+    uv add vyper==0.4.x
+
+Ensure that you replace `0.4.x` with the version of ``vyper`` that is compatible with your project.
+Check your ``pyproject.toml`` file for the required version of ``vyper``. For example:
+
+.. code-block:: toml
+
+    dependencies = ["moccasin==0.4.0", "vyper==0.4.1"]


### PR DESCRIPTION
This pull request updates the `docs/source/common_errors.rst` file to include detailed explanations and solutions for several common errors encountered in discussion tab of mox full course. These additions aim to improve user troubleshooting by providing clear guidance for resolving issues related to missing directories, version mismatches, and deployment errors.

### New error documentation:

* **FileNotFoundError**:
  - Added explanation for the error caused by a missing `lib` directory and its subdirectories (`github` and `pypi`).
  - Provided instructions to manually create the directories or use the `mox install` command to generate them automatically.

* **VersionException**:
  - Documented the issue with incompatible Vyper versions when using the VSCode Vyper extension.
  - Suggested updating the `vyper.command` setting in `.vscode/settings.json` to use the project's virtual environment.

* **AssertionError (ZKsync)**:
  - Explained the error related to bytecode length during contract deployment on ZKsync.
  - Recommended adding `moccasin` and the appropriate `vyper` version to the project's virtual environment using `uv add`.