### PR TITLE
docs: rework project network script documentation

### DIFF
--- a/docs/source/_autogenerated/fork_defaults.rst
+++ b/docs/source/_autogenerated/fork_defaults.rst
@@ -1,4 +1,4 @@
-is_zksync = "true"
+is_zksync = "false"
 prompt_live = "false"
 save_to_db = "false"
 live_or_staging = "false"

--- a/docs/source/core_concepts/named_contracts.rst
+++ b/docs/source/core_concepts/named_contracts.rst
@@ -94,7 +94,7 @@ Let's break these down:
     - A "raw" ABI string
 - ``abi_from_explorer``: If you want to get the ABI from an explorer. This is useful if you don't have the ABI and you want to get it from a public source. You'll need to set a ``explorer_api_key`` in your ``moccasin.toml``, or an ``EXPLORER_API_KEY`` environment variable.
 - ``deployment_script``: The path to the :doc:`deployment script </core_concepts/scripting/deploy>` for this named contract, this will be a shorthand for deploying in the future. 
-- ``force_deploy```: If you want to force deploy the contract when :ref:`manifesting <manifesting>` the contract.
+- ``force_deploy``: If you want to force deploy the contract when :ref:`manifesting <manifesting>` the contract.
 
 As we know, to interact with a contract, one of the most important things is the ABI. For us to interact with any named contract, we give it an ABI, and we can start interacting with that named contract using the ``manifest_named`` function. 
 

--- a/docs/source/core_concepts/project.rst
+++ b/docs/source/core_concepts/project.rst
@@ -7,6 +7,7 @@ A typical moccasin project is structured as follows:
 
     .
     ├── README.md
+    ├── lib/
     ├── moccasin.toml
     ├── script/
     ├── src/
@@ -16,6 +17,7 @@ A typical moccasin project is structured as follows:
 Where:
 
 - ``README.md`` is a markdown file that you can use to describe your project.
+- ``lib/`` is a directory that contains :doc:`moccasin depedencies <dependencies>` that you can use inside your contracts.
 - ``moccasin.toml`` is a configuration file that ``moccasin`` uses to manage the project.
 - ``script`` is a directory that contains python scripts that you can use to deploy your project.
 - ``src``` is a directory that contains your vyper smart contracts.
@@ -32,6 +34,10 @@ If you wanted to adjust your contracts location, for example, have your smart co
     [project]
     src = "contracts"
 
+You can also change the location of your scripts, compiler output, and moccasin libraries by updating the ``moccasin.toml`` file.
+
+See :doc:`moccasin toml parameters </all_moccasin_toml_parameters>` doc for a full list of options you can set in your ``moccasin.toml`` file.
+
 
 Vyper Compiler Options 
 ======================
@@ -40,7 +46,9 @@ By default, ``moccasin`` discourages passing compiler options in the ``moccasin.
 
 .. code-block:: python
 
-    # pragma version ^0.4.1
+    # pragma version >=0.4.1
     # pragma enable-decimals
 
     some_value: public(decimal)
+
+See other `vyper compiler options <https://docs.vyperlang.org/en/stable/compiling-a-contract.html#enabling-experimental-code-generation>`_ for more information.

--- a/docs/source/core_concepts/script.rst
+++ b/docs/source/core_concepts/script.rst
@@ -87,6 +87,8 @@ You can directly import contracts from the ``src`` folder into your scripts, and
 
     deploy()
 
+Under the hood, the contract is imported as a `Titanoboa VyperDeployer instance <https://titanoboa.readthedocs.io/en/latest/api/vyper_deployer/overview/>`_, which allows you to use ``Counter.deploy()`` to get a `Titanoboa VyperContract instance <https://titanoboa.readthedocs.io/en/latest/api/vyper_deployer/overview/>`_ and interact with it.
+
 Networking 
 ==========
 


### PR DESCRIPTION

This pull request primarily updates the documentation for the Moccasin project, introducing clarifications, new examples, and additional references. The most significant changes include adjustments to project structure descriptions, updates to configuration options, and improvements in code examples.

### Updates to project structure and configuration:

* Added a new `lib/` directory to the example Moccasin project structure and described its purpose for storing Moccasin dependencies. (`docs/source/core_concepts/project.rst`, [[1]](diffhunk://#diff-bff5af552de68e531f6b384807dad13cece2f03b99aea67dba6436355e574e47R10) [[2]](diffhunk://#diff-bff5af552de68e531f6b384807dad13cece2f03b99aea67dba6436355e574e47R20)
* Included instructions on customizing the locations of scripts, compiler output, and libraries in the `moccasin.toml` file, with a reference to the full list of configuration options. (`docs/source/core_concepts/project.rst`, [docs/source/core_concepts/project.rstR37-R40](diffhunk://#diff-bff5af552de68e531f6b384807dad13cece2f03b99aea67dba6436355e574e47R37-R40))

### Improvements to code examples:

* Updated the Vyper compiler pragma example to use `>=0.4.1` instead of `^0.4.1` and added a link to additional Vyper compiler options. (`docs/source/core_concepts/project.rst`, [docs/source/core_concepts/project.rstL43-R54](diffhunk://#diff-bff5af552de68e531f6b384807dad13cece2f03b99aea67dba6436355e574e47L43-R54))
* Fixed a typo in the `force_deploy` option description for named contracts. (`docs/source/core_concepts/named_contracts.rst`, [docs/source/core_concepts/named_contracts.rstL97-R97](diffhunk://#diff-4f6bee89fc0be8b485b084d409af4092c66a36aa26185fe6055fcf2f039b57f1L97-R97))

### Additional references:

* Added an explanation of how contracts are imported as Titanoboa `VyperDeployer` and `VyperContract` instances, with links to the relevant Titanoboa documentation. (`docs/source/core_concepts/script.rst`, [docs/source/core_concepts/script.rstR90-R91](diffhunk://#diff-0751c9db4171c9fd708b72b0712c61dc6d88fb41e5fecad8005431fe227f989bR90-R91))

### Minor updates:

* Changed the `is_zksync` default value from `true` to `false` in the `fork_defaults.rst` documentation. (`docs/source/_autogenerated/fork_defaults.rst`, [docs/source/_autogenerated/fork_defaults.rstL1-R1](diffhunk://#diff-692dbbd9415bffb6897dffcc20d9ec49c77645fe5aebf2fcc46cd0853dc61517L1-R1))