### PR TITLE
fix: resolve CLI command aliases to canonical handlers

### DIFF
--- a/moccasin/__main__.py
+++ b/moccasin/__main__.py
@@ -185,7 +185,7 @@ If no contract or contract path is given, this command will:
 
 Use this command to prepare your contracts for deployment or testing.""",
         formatter_class=argparse.RawDescriptionHelpFormatter,
-        aliases=["build"],
+        aliases=["build", "c"],
         parents=[parent_parser],
     )
 

--- a/moccasin/commands/wallet.py
+++ b/moccasin/commands/wallet.py
@@ -17,7 +17,16 @@ from moccasin.constants.vars import (
 )
 from moccasin.logging import logger
 
-ALIAS_TO_COMMAND = {"add": "import", "i": "import", "kl": "keystore-location"}
+ALIAS_TO_COMMAND = {
+    "ls": "list",
+    "g": "generate",
+    "new": "generate",
+    "add": "import",
+    "i": "import",
+    "dk": "decrypt",
+    "d": "delete",
+    "kl": "keystore-location",
+}
 
 
 def main(args: Namespace) -> int:

--- a/tests/cli/test_cli_compile.py
+++ b/tests/cli/test_cli_compile.py
@@ -27,6 +27,16 @@ def test_build_help(mox_path):
     assert result.returncode == 0
 
 
+def test_compile_short_alias_help(mox_path):
+    result = subprocess.run(
+        [mox_path, "c", "-h"], check=True, capture_output=True, text=True
+    )
+    assert EXPECTED_HELP_TEXT in result.stdout, (
+        "Help output does not contain expected text"
+    )
+    assert result.returncode == 0
+
+
 def test_compile_alias_build_project(
     complex_temp_path,
     complex_cleanup_out_folder,
@@ -66,6 +76,27 @@ def test_compile_one(complex_temp_path, complex_cleanup_out_folder, mox_path):
         os.chdir(current_dir.joinpath(complex_temp_path))
         result = subprocess.run(
             [mox_path, "build", "BuyMeACoffee.vy", "--no-install"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    finally:
+        os.chdir(current_dir)
+
+    assert not complex_temp_path.joinpath(LIB_GH_PATH).exists()
+    assert not complex_temp_path.joinpath(LIB_PIP_PATH).exists()
+    assert "Done compiling BuyMeACoffee" in result.stderr
+    assert result.returncode == 0
+
+
+def test_compile_short_alias_one(
+    complex_temp_path, complex_cleanup_out_folder, mox_path
+):
+    current_dir = Path.cwd()
+    try:
+        os.chdir(current_dir.joinpath(complex_temp_path))
+        result = subprocess.run(
+            [mox_path, "c", "BuyMeACoffee.vy", "--no-install"],
             check=True,
             capture_output=True,
             text=True,

--- a/tests/cli/test_cli_explorer.py
+++ b/tests/cli/test_cli_explorer.py
@@ -1,0 +1,23 @@
+import subprocess
+
+
+def test_explorer_fetch_alias_help(mox_path):
+    result = subprocess.run(
+        [mox_path, "explorer", "get", "-h"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    assert "explorer fetch" in result.stdout
+    assert result.returncode == 0
+
+
+def test_explorer_list_runs(mox_path):
+    result = subprocess.run(
+        [mox_path, "explorer", "list"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    assert "Supported explorers" in result.stderr
+    assert result.returncode == 0

--- a/tests/cli/test_cli_utils.py
+++ b/tests/cli/test_cli_utils.py
@@ -1,0 +1,33 @@
+import subprocess
+
+import pytest
+
+
+EXPECTED_ZERO_ADDRESS = "0x0000000000000000000000000000000000000000"
+
+
+@pytest.mark.parametrize(
+    "utils_command",
+    ["zero", "zero-address", "zero_address", "address-zero", "address_zero"],
+)
+def test_utils_zero_aliases(mox_path, utils_command):
+    result = subprocess.run(
+        [mox_path, "utils", utils_command],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    assert result.stdout.strip() == EXPECTED_ZERO_ADDRESS
+    assert result.returncode == 0
+
+
+@pytest.mark.parametrize("utils_alias", ["u", "util"])
+def test_utils_command_aliases(mox_path, utils_alias):
+    result = subprocess.run(
+        [mox_path, utils_alias, "zero"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    assert result.stdout.strip() == EXPECTED_ZERO_ADDRESS
+    assert result.returncode == 0

--- a/tests/cli/test_cli_wallet.py
+++ b/tests/cli/test_cli_wallet.py
@@ -2,6 +2,9 @@ import os
 import subprocess
 from pathlib import Path
 
+import pytest
+
+import moccasin.constants.vars as vars
 from moccasin.constants.vars import MOCCASIN_KEYSTORES_FOLDER_NAME
 from tests.constants import COMPLEX_PROJECT_PATH
 
@@ -54,3 +57,98 @@ def test_run_keystore_location_custom(mox_path, custom_moccasin_keystore_path):
         f"Keystore location: {str(custom_moccasin_keystore_path)} (custom location)"
         in result.stderr
     )
+
+
+def test_run_keystore_location_alias(
+    mox_path, moccasin_home_folder, session_monkeypatch
+):
+    default_keystore = moccasin_home_folder.joinpath(MOCCASIN_KEYSTORES_FOLDER_NAME)
+    session_monkeypatch.setenv("MOCCASIN_KEYSTORE_PATH", str(default_keystore))
+    session_monkeypatch.setattr(vars, "MOCCASIN_KEYSTORE_PATH", default_keystore)
+
+    current_dir = Path.cwd()
+    try:
+        os.chdir(COMPLEX_PROJECT_PATH)
+        result = subprocess.run(
+            [mox_path, "wallet", "kl"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    finally:
+        os.chdir(current_dir)
+    output = result.stderr + result.stdout
+    assert (
+        f"Keystore location: {default_keystore} (default location)" in output
+    )
+    assert "Unknown accounts command" not in output
+
+
+def test_run_wallet_list_alias(mox_path):
+    current_dir = Path.cwd()
+    try:
+        os.chdir(COMPLEX_PROJECT_PATH)
+        result = subprocess.run(
+            [mox_path, "wallet", "ls"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    finally:
+        os.chdir(current_dir)
+    assert "Unknown accounts command" not in result.stderr
+
+
+@pytest.mark.parametrize("wallet_alias", ["g", "new"])
+def test_run_wallet_generate_aliases(mox_path, wallet_alias):
+    current_dir = Path.cwd()
+    try:
+        os.chdir(COMPLEX_PROJECT_PATH)
+        result = subprocess.run(
+            [mox_path, "wallet", wallet_alias, "test-alias-account"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    finally:
+        os.chdir(current_dir)
+    assert "Account generated:" in result.stderr
+    assert "Unknown accounts command" not in result.stderr
+
+
+def test_run_wallet_delete_alias_for_missing_account(mox_path):
+    current_dir = Path.cwd()
+    try:
+        os.chdir(COMPLEX_PROJECT_PATH)
+        result = subprocess.run(
+            [mox_path, "wallet", "d", "missing-alias-account"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    finally:
+        os.chdir(current_dir)
+    assert "Account with name missing-alias-account does not exist" in result.stderr
+    assert "Unknown accounts command" not in result.stderr
+
+
+@pytest.mark.parametrize(
+    ("wallet_alias", "canonical_command"),
+    [
+        ("ls", "list"),
+        ("g", "generate"),
+        ("new", "generate"),
+        ("i", "import"),
+        ("add", "import"),
+        ("dk", "decrypt"),
+        ("d", "delete"),
+    ],
+)
+def test_wallet_alias_help(mox_path, wallet_alias, canonical_command):
+    result = subprocess.run(
+        [mox_path, "wallet", wallet_alias, "-h"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    assert f"wallet {canonical_command}" in result.stdout


### PR DESCRIPTION
## Summary
- Fix wallet alias dispatch so abbreviations like `mox wallet ls` resolve correctly
- Wallet shortcuts like `ls`, `g`, and `dk` now work as expected
- Register `c` as a top-level alias for `compile`
- Add CLI regression tests for wallet, compile, explorer, and utils aliases
## Test plan
- [x] `uv run pytest tests/cli/test_cli_wallet.py tests/cli/test_cli_compile.py tests/cli/test_cli_explorer.py tests/cli/test_cli_utils.py`
- [x] Verified `mox wallet ls` no longer prints "Unknown accounts command"