### PR TITLE
fix: respect `config.script_folder` in mox run

### DIFF
--- a/moccasin/commands/run.py
+++ b/moccasin/commands/run.py
@@ -117,14 +117,16 @@ def run_script(
 
 
 def get_script_path(script_name_or_path: Path | str) -> Path:
+    config = get_config()
+    script_folder = config.script_folder
     script_path = Path(script_name_or_path)
-    root = get_config().get_root()
+    root = config.get_root()
     if script_path.suffix != ".py":
         script_path = script_path.with_suffix(".py")
 
     if not script_path.is_absolute():
-        if "script" not in script_path.parts:
-            script_path = root / "script" / script_path
+        if script_folder not in script_path.parts:
+            script_path = root / script_folder / script_path
         else:
             script_path = root / script_path
 

--- a/tests/unit/test_unit_run.py
+++ b/tests/unit/test_unit_run.py
@@ -20,6 +20,24 @@ def test_get_script_path_for_absolute_path(complex_temp_path, complex_project_co
     assert script_path == complex_project_config.get_root() / "script/deploy.py"
 
 
+def test_get_script_path_respects_configured_script_folder(monkeypatch, tmp_path):
+    # A project may override the script folder (e.g. `script = "scripts"`); `mox run`
+    # must resolve scripts under the configured folder, not the hardcoded default.
+    (tmp_path / "scripts").mkdir()
+    (tmp_path / "scripts" / "deploy.py").write_text("")
+
+    class _Config:
+        script_folder = "scripts"
+
+        def get_root(self):
+            return tmp_path
+
+    monkeypatch.setattr("moccasin.commands.run.get_config", lambda: _Config())
+    assert get_script_path("deploy") == tmp_path / "scripts" / "deploy.py"
+    # a relative path that already includes the configured folder is used as-is
+    assert get_script_path("scripts/deploy.py") == tmp_path / "scripts" / "deploy.py"
+
+
 def test_no_prompt_on_test_networks(complex_project_config, capsys):
     current_dir = Path.cwd()
     try:


### PR DESCRIPTION
## Description

`mox run <script>` ignores a project's configured `script` folder and always looks under a hardcoded `script/` directory. A project that sets, e.g.:

```toml
[project]  # moccasin.toml (or [tool.moccasin.project] in pyproject.toml)
script = "scripts"
```

fails with `<root>/script/<name>.py not found`, even though `config.script_folder` resolves correctly to `scripts` everywhere else (e.g. deploy scripts via `config.py`). The bug is isolated to `get_script_path` in `moccasin/commands/run.py`, which hardcoded the literal `"script"` instead of reading `config.script_folder`.

This PR makes `get_script_path` resolve script paths against `config.script_folder`.

The default (`"script"`) behavior is unchanged, so existing projects are unaffected.

I audited the other configurable folder properties (`src`/`contracts`, `out`/`build`, `lib`) and their consumers (`compile`, `format`, `lint`, `inspect`, `purge`, `_sys_path_and_config_setup`) all already read from config correctly. `script` was the sole offender. (`test_folder` is intentionally fixed to `tests/` by design and is out of scope.)

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Documentation
- [ ] Other

## Related Issue(s)

_(None)_

## Checklist

- [x] I have removed any unrelated changes from this PR
- [ ] I’ve run `just test-all` and ensured all tests pass
- [ ] I’ve run `just typecheck` and resolved any typing issues
- [ ] I’ve run `just format` to auto-format code

If any new functionality was added or changed, were tests included?

- [x] Yes, tests were added/updated
- [ ] No, and I understand this will likely delay review/merge
- [ ] N/A

## Platform/Environment Tested

- [x] Linux / macOS
- [ ] Dev Container (VSCode)
- [ ] Other:

## Notes for Reviewers

The added unit test (`test_get_script_path_respects_configured_script_folder`) monkeypatches `get_config` so it exercises `get_script_path` in isolation without needing a full project fixture. It covers both a bare script name and a relative path that already includes the configured folder. Existing `get_script_path` tests (default `script/` folder, relative, absolute) continue to pass unchanged.

I was not able to run the full `just test-all` / `just typecheck` / `just format` locally in my environment; the change is a 3-line substitution plus a focused unit test, so CI should cover it.
